### PR TITLE
build(ci): Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.8.4
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
@@ -19,22 +19,22 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.1"
+    rev: "v1.14.0"
     hooks:
       - id: mypy
         additional_dependencies: ['numpy >= 1.22', "ml-dtypes >= 0.1", "pytest"]
         args: [--show-error-codes]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v18.1.5"
+    rev: "v19.1.5"
     hooks:
       - id: clang-format
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.16.2
+    rev: v0.16.6
     hooks:
       - id: cython-lint
       - id: double-quote-cython-strings
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.8.0-1
+    rev: v3.10.0-2
     hooks:
       - id: shfmt
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -47,7 +47,7 @@ repos:
   #     - id: cmake-format
   #     - id: cmake-lint
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.1.1
+    rev: v4.0.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/include/mlc/core/object.h
+++ b/include/mlc/core/object.h
@@ -75,38 +75,38 @@ struct Object {
 /******************* Section 2. Object Ref *******************/
 
 namespace mlc {
-#define MLC_DEF_OBJ_REF(SelfType, ObjType, ParentType)                                                                                                \
-public:                                                                                                                                               \
-  [[maybe_unused]] static constexpr ::mlc::base::TypeKind _type_kind = ::mlc::base::TypeKind::kObjRef;                                                \
-  using TSelf = SelfType;                                                                                                                             \
-  using TObj = ObjType;                                                                                                                               \
-  using TObjRef = SelfType;                                                                                                                           \
-                                                                                                                                                      \
-private:                                                                                                                                              \
-  using TBase = ::mlc::base::PtrBase;                                                                                                                 \
-  template <typename U> using DObj = std::enable_if_t<::mlc::base::IsDerivedFrom<U, TObj>>;                                                           \
-  template <typename U> using DObjRef = std::enable_if_t<::mlc::base::IsDerivedFromObjRef<U, TObj>>;                                                  \
-  template <typename U> using DOpt = std::enable_if_t<::mlc::base::IsDerivedFromOpt<U, TObj>>;                                                        \
-                                                                                                                                                      \
-public:                                                                                                                                               \
-  /***** Section 1. Default constructor/destructors *****/                                                                                            \
-  MLC_INLINE SelfType(std::nullptr_t) = delete;                                                                                                       \
-  MLC_INLINE SelfType(::mlc::NullType) : ParentType(::mlc::Null) {}                                                                                   \
-  MLC_INLINE SelfType &operator=(std::nullptr_t) = delete;                                                                                            \
-  MLC_INLINE SelfType &operator=(::mlc::NullType) { return this->Reset(); }                                                                           \
-  MLC_INLINE ~SelfType() = default;                                                                                                                   \
+#define MLC_DEF_OBJ_REF(SelfType, ObjType, ParentType)                                                                 \
+public:                                                                                                                \
+  [[maybe_unused]] static constexpr ::mlc::base::TypeKind _type_kind = ::mlc::base::TypeKind::kObjRef;                 \
+  using TSelf = SelfType;                                                                                              \
+  using TObj = ObjType;                                                                                                \
+  using TObjRef = SelfType;                                                                                            \
+                                                                                                                       \
+private:                                                                                                               \
+  using TBase = ::mlc::base::PtrBase;                                                                                  \
+  template <typename U> using DObj = std::enable_if_t<::mlc::base::IsDerivedFrom<U, TObj>>;                            \
+  template <typename U> using DObjRef = std::enable_if_t<::mlc::base::IsDerivedFromObjRef<U, TObj>>;                   \
+  template <typename U> using DOpt = std::enable_if_t<::mlc::base::IsDerivedFromOpt<U, TObj>>;                         \
+                                                                                                                       \
+public:                                                                                                                \
+  /***** Section 1. Default constructor/destructors *****/                                                             \
+  MLC_INLINE SelfType(std::nullptr_t) = delete;                                                                        \
+  MLC_INLINE SelfType(::mlc::NullType) : ParentType(::mlc::Null) {}                                                    \
+  MLC_INLINE SelfType &operator=(std::nullptr_t) = delete;                                                             \
+  MLC_INLINE SelfType &operator=(::mlc::NullType) { return this->Reset(); }                                            \
+  MLC_INLINE ~SelfType() = default;                                                                                    \
   /* clang-format off */                                                                                    \
   MLC_INLINE SelfType(const TSelf &src) : ParentType(::mlc::Null) { this->_Set(src.ptr); TBase::IncRef(); } \
   MLC_INLINE SelfType(TSelf &&src) : ParentType(::mlc::Null) { this->_Set(src.ptr); src.ptr = nullptr; }    \
   MLC_INLINE TSelf &operator=(const TSelf &other) { TSelf(other).Swap(*this); return *this; }               \
   MLC_INLINE TSelf &operator=(TSelf &&other) { TSelf(std::move(other)).Swap(*this); return *this; }         \
-  MLC_INLINE TSelf &Reset() { TBase::Reset(); return *this; }                                         \
-  /* clang-format on */                                                                                                                               \
-  /***** Section 2. The `new` operator *****/                                                                                                         \
-  template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<TObj, Args...>>>                                                    \
-  MLC_INLINE explicit SelfType(Args &&...args)                                                                                                        \
-      : SelfType(::mlc::base::AllocatorOf<TObj>::New(std::forward<Args>(args)...)) {}                                                                 \
-  /***** Section 3. From derived pointers *****/                                                                                                      \
+  MLC_INLINE TSelf &Reset() { TBase::Reset(); return *this; }          \
+  /* clang-format on */                                                                                                \
+  /***** Section 2. The `new` operator *****/                                                                          \
+  template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<TObj, Args...>>>                     \
+  MLC_INLINE explicit SelfType(Args &&...args)                                                                         \
+      : SelfType(::mlc::base::AllocatorOf<TObj>::New(std::forward<Args>(args)...)) {}                                  \
+  /***** Section 3. From derived pointers *****/                                                                       \
   /* clang-format off */                                                                                                                                                                                                          \
   template <typename U, typename = DObj<U>> MLC_INLINE explicit SelfType(const U *src) : ParentType(::mlc::Null) { this->_Set(reinterpret_cast<const MLCAny *>(src)); TBase::IncRef(); TBase::CheckNull<TSelf>(); }               \
   template <typename U, typename = DObj<U>> MLC_INLINE SelfType(const ::mlc::Ref<U> &src) : ParentType(::mlc::Null) { TBase::_Set(reinterpret_cast<const MLCObjPtr &>(src)); TBase::IncRef(); TBase::CheckNull<TSelf>(); }        \
@@ -118,45 +118,45 @@ public:                                                                         
   template <typename U, typename = DObj<U>> MLC_INLINE TSelf &operator=(const ::mlc::Ref<U> &other) { TSelf(other).Swap(*this); return *this; }                                                                                   \
   template <typename U, typename = DObj<U>> MLC_INLINE TSelf &operator=(::mlc::Ref<U> &&other) { TSelf(std::move(other)).Swap(*this); return *this; }                                                                             \
   template <typename U, typename = DObj<U>> MLC_INLINE TSelf &operator=(const ::mlc::Optional<U> &other) { TSelf(other).Swap(*this); return *this; }                                                                              \
-  template <typename U, typename = DObj<U>> MLC_INLINE TSelf &operator=(::mlc::Optional<U> &&other) { TSelf(std::move(other)).Swap(*this); return *this; } \
-  /* clang-format on */                                                                                                                               \
-  /***** Section 4. Conversion between AnyView/Any *****/                                                                                             \
-  MLC_INLINE SelfType(const ::mlc::AnyView *src) : ParentType(::mlc::Null) {                                                                          \
-    TBase::_Init<TObj>(src);                                                                                                                          \
-    TBase::CheckNull<TSelf>();                                                                                                                        \
-  }                                                                                                                                                   \
-  MLC_INLINE SelfType(const ::mlc::Any *src) : ParentType(::mlc::Null) {                                                                              \
-    TBase::_Init<TObj>(src);                                                                                                                          \
-    TBase::CheckNull<TSelf>();                                                                                                                        \
-  }                                                                                                                                                   \
-  MLC_INLINE operator ::mlc::AnyView() const { return ::mlc::AnyView(this->get()); };                                                                 \
-  MLC_INLINE operator ::mlc::Any() const { return ::mlc::Any(this->get()); }                                                                          \
-  /***** Section 5. Accessor, comparators and stringify *****/                                                                                        \
-  MLC_INLINE const TObj *get() const { return reinterpret_cast<const TObj *>(this->ptr); }                                                            \
-  MLC_INLINE TObj *get() { return reinterpret_cast<TObj *>(ptr); }                                                                                    \
-  MLC_INLINE const TObj *operator->() const { return get(); }                                                                                         \
-  MLC_INLINE TObj *operator->() { return get(); }                                                                                                     \
-  MLC_INLINE const TObj &operator*() const {                                                                                                          \
-    if (const TObj *ret = get()) {                                                                                                                    \
-      return *ret;                                                                                                                                    \
-    }                                                                                                                                                 \
-    MLC_THROW(ValueError) << "Attempt to dereference a null pointer";                                                                                 \
-    MLC_UNREACHABLE();                                                                                                                                \
-  }                                                                                                                                                   \
-  MLC_INLINE TObj &operator*() {                                                                                                                      \
-    if (TObj *ret = get()) {                                                                                                                          \
-      return *ret;                                                                                                                                    \
-    }                                                                                                                                                 \
-    MLC_THROW(ValueError) << "Attempt to dereference a null pointer";                                                                                 \
-    MLC_UNREACHABLE();                                                                                                                                \
-  }                                                                                                                                                   \
-  MLC_INLINE bool defined() const { return TBase::ptr != nullptr; }                                                                                   \
-  MLC_INLINE bool has_value() const { return TBase::ptr != nullptr; }                                                                                 \
-  MLC_INLINE bool operator==(std::nullptr_t) const { return TBase::ptr == nullptr; }                                                                  \
-  MLC_INLINE bool operator!=(std::nullptr_t) const { return TBase::ptr != nullptr; }                                                                  \
-  /***** Section 6. Runtime-type information *****/                                                                                                   \
-  MLC_DEF_RTTI_METHODS(true, TBase::ptr, TBase::ptr)                                                                                                  \
-  static inline const int32_t _type_reflect =                                                                                                         \
+  template <typename U, typename = DObj<U>> MLC_INLINE TSelf &operator=(::mlc::Optional<U> &&other) { TSelf(std::move(other)).Swap(*this); return *this; }                                                                                 \
+  /* clang-format on */                                                                                                \
+  /***** Section 4. Conversion between AnyView/Any *****/                                                              \
+  MLC_INLINE SelfType(const ::mlc::AnyView *src) : ParentType(::mlc::Null) {                                           \
+    TBase::_Init<TObj>(src);                                                                                           \
+    TBase::CheckNull<TSelf>();                                                                                         \
+  }                                                                                                                    \
+  MLC_INLINE SelfType(const ::mlc::Any *src) : ParentType(::mlc::Null) {                                               \
+    TBase::_Init<TObj>(src);                                                                                           \
+    TBase::CheckNull<TSelf>();                                                                                         \
+  }                                                                                                                    \
+  MLC_INLINE operator ::mlc::AnyView() const { return ::mlc::AnyView(this->get()); };                                  \
+  MLC_INLINE operator ::mlc::Any() const { return ::mlc::Any(this->get()); }                                           \
+  /***** Section 5. Accessor, comparators and stringify *****/                                                         \
+  MLC_INLINE const TObj *get() const { return reinterpret_cast<const TObj *>(this->ptr); }                             \
+  MLC_INLINE TObj *get() { return reinterpret_cast<TObj *>(ptr); }                                                     \
+  MLC_INLINE const TObj *operator->() const { return get(); }                                                          \
+  MLC_INLINE TObj *operator->() { return get(); }                                                                      \
+  MLC_INLINE const TObj &operator*() const {                                                                           \
+    if (const TObj *ret = get()) {                                                                                     \
+      return *ret;                                                                                                     \
+    }                                                                                                                  \
+    MLC_THROW(ValueError) << "Attempt to dereference a null pointer";                                                  \
+    MLC_UNREACHABLE();                                                                                                 \
+  }                                                                                                                    \
+  MLC_INLINE TObj &operator*() {                                                                                       \
+    if (TObj *ret = get()) {                                                                                           \
+      return *ret;                                                                                                     \
+    }                                                                                                                  \
+    MLC_THROW(ValueError) << "Attempt to dereference a null pointer";                                                  \
+    MLC_UNREACHABLE();                                                                                                 \
+  }                                                                                                                    \
+  MLC_INLINE bool defined() const { return TBase::ptr != nullptr; }                                                    \
+  MLC_INLINE bool has_value() const { return TBase::ptr != nullptr; }                                                  \
+  MLC_INLINE bool operator==(std::nullptr_t) const { return TBase::ptr == nullptr; }                                   \
+  MLC_INLINE bool operator!=(std::nullptr_t) const { return TBase::ptr != nullptr; }                                   \
+  /***** Section 6. Runtime-type information *****/                                                                    \
+  MLC_DEF_RTTI_METHODS(true, TBase::ptr, TBase::ptr)                                                                   \
+  static inline const int32_t _type_reflect =                                                                          \
       ::mlc::core::ReflectionHelper(static_cast<int32_t>(TObj::_type_index)).Init<TObj>()
 
 struct ObjectRef : protected ::mlc::core::ObjectRefDummyRoot {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,6 @@ line-length = 100
 indent-width = 4
 target-version = "py39"
 include = ["pyproject.toml", "python/**/*.py", "tests/python/**/*.py"]
-
-[tool.ruff.lint]
 select = [
     "UP",  # pyupgrade, https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "PL",  # pylint, https://docs.astral.sh/ruff/rules/#pylint-pl
@@ -72,13 +70,12 @@ select = [
 ]
 ignore = [
     "PLR2004", # pylint: magic-value-comparison
-    "ANN101",  # flake8-annotations: missing-type-self
     "ANN401",  # flake8-annotations: any-type
 ]
 fixable = ["ALL"]
 unfixable = []
 
-[tool.ruff.lint.per-file-ignores]
+[tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 
 [tool.ruff.format]


### PR DESCRIPTION
This commit contains a couple of changes of linters
- Moves section `[tool.ruff.lint]` under `[tool.ruff]` in `pyproject.toml`, according to schema validation from [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml);
- Removes rule [`ANN101`](https://docs.astral.sh/ruff/rules/missing-type-self/) which has been deprecated in Ruff.
- Updates a few pre-commit hooks
  - shfmt: v3.8.0-1 ~ v3.10.0-2
  - ruff: v0.4.7 ~ v0.8.4
  - mypy: v1.11.1 ~ v1.14.0
  - clang-format: v18.1.5 ~ v19.1.5
  - cython-lint: v0.16.2 ~ v0.16.6
  - conventional commit: v2.1.1 ~ v4.0.0