### PR TITLE
feat(core): Interop torch.dtype/torch.device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 env:
   CIBW_BUILD_VERBOSITY: 3
-  CIBW_TEST_REQUIRES: "pytest"
+  CIBW_TEST_REQUIRES: "pytest torch"
   CIBW_TEST_COMMAND: "pytest -svv --durations=20 {project}/tests/python/"
   MLC_CIBW_VERSION: "2.22.0"
   MLC_PYTHON_VERSION: "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.9.0
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
@@ -22,13 +22,13 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.0"
+    rev: "v1.14.1"
     hooks:
       - id: mypy
-        additional_dependencies: ['numpy >= 1.22', "ml-dtypes >= 0.1", "pytest"]
+        additional_dependencies: ['numpy >= 1.22', "ml-dtypes >= 0.1", "pytest", "torch"]
         args: [--show-error-codes]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v19.1.5"
+    rev: "v19.1.6"
     hooks:
       - id: clang-format
   - repo: https://github.com/MarcoGorelli/cython-lint

--- a/cpp/c_api.cc
+++ b/cpp/c_api.cc
@@ -19,7 +19,6 @@ using ::mlc::registry::TypeTable;
 
 namespace {
 thread_local Any last_error;
-MLC_REGISTER_FUNC("mlc.ffi.LoadDSO").set_body([](std::string name) { TypeTable::Get(nullptr)->LoadDSO(name); });
 } // namespace
 
 MLC_API MLCAny MLCGetLastError() {

--- a/cpp/registry.h
+++ b/cpp/registry.h
@@ -255,6 +255,128 @@ struct TypeTable {
   std::unordered_map<std::string, FuncObj *> global_funcs;
   std::unordered_map<std::string, std::unique_ptr<VTable>> global_vtables;
   std::unordered_map<std::string, std::unique_ptr<DSOLibrary>> dso_libraries;
+  std::unordered_map<std::string, DLDataType> dtype_presets{
+      {"void", {kDLOpaqueHandle, 0, 0}},
+      {"bool", {kDLUInt, 1, 1}},
+      {"int2", {kDLInt, 2, 1}},
+      {"int4", {kDLInt, 4, 1}},
+      {"int8", {kDLInt, 8, 1}},
+      {"int16", {kDLInt, 16, 1}},
+      {"int32", {kDLInt, 32, 1}},
+      {"int64", {kDLInt, 64, 1}},
+      {"uint2", {kDLUInt, 2, 1}},
+      {"uint4", {kDLUInt, 4, 1}},
+      {"uint8", {kDLUInt, 8, 1}},
+      {"uint16", {kDLUInt, 16, 1}},
+      {"uint32", {kDLUInt, 32, 1}},
+      {"uint64", {kDLUInt, 64, 1}},
+      {"float16", {kDLFloat, 16, 1}},
+      {"float32", {kDLFloat, 32, 1}},
+      {"float64", {kDLFloat, 64, 1}},
+      // bfloat16
+      {"bfloat16", {kDLBfloat, 16, 1}},
+      // 8-bit floating point representations
+      {"float8_e3m4", {kDLDataTypeFloat8E3M4, 8, 1}},
+      {"float8_e4m3", {kDLDataTypeFloat8E4M3, 8, 1}},
+      {"float8_e4m3b11fnuz", {kDLDataTypeFloat8E4M3B11FNUZ, 8, 1}},
+      {"float8_e4m3fn", {kDLDataTypeFloat8E4M3FN, 8, 1}},
+      {"float8_e4m3fnuz", {kDLDataTypeFloat8E4M3FNUZ, 8, 1}},
+      {"float8_e5m2", {kDLDataTypeFloat8E5M2, 8, 1}},
+      {"float8_e5m2fnuz", {kDLDataTypeFloat8E5M2FNUZ, 8, 1}},
+      {"float8_e8m0fnu", {kDLDataTypeFloat8E8M0FNU, 8, 1}},
+      // Microscaling (MX) sub-byte floating point representations
+      {"float4_e2m1fn", {kDLDataTypeFloat4E2M1FN, 4, 1}}, // higher 4 bits are unused
+      {"float6_e2m3fn", {kDLDataTypeFloat6E2M3FN, 6, 1}}, // higher 2 bits are unused
+      {"float6_e3m2fn", {kDLDataTypeFloat6E3M2FN, 6, 1}}, // higher 2 bits are unused
+  };
+  std::unordered_map<int32_t, std::string> dtype_code_to_str{
+      {kDLInt, "int"},
+      {kDLUInt, "uint"},
+      {kDLFloat, "float"},
+      {kDLOpaqueHandle, "ptr"},
+      {kDLBfloat, "bfloat"},
+      {kDLComplex, "complex"},
+      {kDLBool, "bool"},
+      /* 8-bit floating point representations */
+      {kDLDataTypeFloat8E3M4, "float8_e3m4"},
+      {kDLDataTypeFloat8E4M3, "float8_e4m3"},
+      {kDLDataTypeFloat8E4M3B11FNUZ, "float8_e4m3b11fnuz"},
+      {kDLDataTypeFloat8E4M3FN, "float8_e4m3fn"},
+      {kDLDataTypeFloat8E4M3FNUZ, "float8_e4m3fnuz"},
+      {kDLDataTypeFloat8E5M2, "float8_e5m2"},
+      {kDLDataTypeFloat8E5M2FNUZ, "float8_e5m2fnuz"},
+      {kDLDataTypeFloat8E8M0FNU, "float8_e8m0fnu"},
+      /* Microscaling (MX) sub-byte floating point representations */
+      {kDLDataTypeFloat4E2M1FN, "float4_e2m1fn"},
+      {kDLDataTypeFloat6E2M3FN, "float6_e2m3fn"},
+      {kDLDataTypeFloat6E3M2FN, "float6_e3m2fn"},
+  };
+  std::unordered_map<std::string, int32_t> dtype_code_from_str{
+      {"int", kDLInt},
+      {"uint", kDLUInt},
+      {"float", kDLFloat},
+      {"ptr", kDLOpaqueHandle},
+      {"bfloat", kDLBfloat},
+      {"complex", kDLComplex},
+      {"bool", kDLBool},
+      /* 8-bit floating point representations */
+      {"float8_e3m4", kDLDataTypeFloat8E3M4},
+      {"float8_e4m3", kDLDataTypeFloat8E4M3},
+      {"float8_e4m3b11fnuz", kDLDataTypeFloat8E4M3B11FNUZ},
+      {"float8_e4m3fn", kDLDataTypeFloat8E4M3FN},
+      {"float8_e4m3fnuz", kDLDataTypeFloat8E4M3FNUZ},
+      {"float8_e5m2", kDLDataTypeFloat8E5M2},
+      {"float8_e5m2fnuz", kDLDataTypeFloat8E5M2FNUZ},
+      {"float8_e8m0fnu", kDLDataTypeFloat8E8M0FNU},
+      /* Microscaling (MX) sub-byte floating point representations */
+      {"float4_e2m1fn", kDLDataTypeFloat4E2M1FN},
+      {"float6_e2m3fn", kDLDataTypeFloat6E2M3FN},
+      {"float6_e3m2fn", kDLDataTypeFloat6E3M2FN},
+  };
+  std::unordered_map<int32_t, std::string> device_type_code_to_str = {
+      {0, "meta"},
+      {kDLCPU, "cpu"},
+      {kDLCUDA, "cuda"},
+      {kDLCUDAHost, "cuda_host"},
+      {kDLOpenCL, "opencl"},
+      {kDLVulkan, "vulkan"},
+      {kDLMetal, "mps"},
+      {kDLVPI, "vpi"},
+      {kDLROCM, "rocm"},
+      {kDLROCMHost, "rocm_host"},
+      {kDLExtDev, "ext_dev"},
+      {kDLCUDAManaged, "cuda_managed"},
+      {kDLOneAPI, "oneapi"},
+      {kDLWebGPU, "webgpu"},
+      {kDLHexagon, "hexagon"},
+      {kDLMAIA, "maia"},
+  };
+  std::unordered_map<std::string, int32_t> device_type_str_to_code = {
+      {"meta", 0},
+      {"cpu", kDLCPU},
+      {"cuda", kDLCUDA},
+      {"cuda_host", kDLCUDAHost},
+      {"opencl", kDLOpenCL},
+      {"vulkan", kDLVulkan},
+      {"mps", kDLMetal},
+      {"vpi", kDLVPI},
+      {"rocm", kDLROCM},
+      {"rocm_host", kDLROCMHost},
+      {"ext_dev", kDLExtDev},
+      {"cuda_managed", kDLCUDAManaged},
+      {"oneapi", kDLOneAPI},
+      {"webgpu", kDLWebGPU},
+      {"hexagon", kDLHexagon},
+      {"maia", kDLMAIA},
+      // aliases
+      {"llvm", kDLCPU},
+      {"nvptx", kDLCUDA},
+      {"cl", kDLOpenCL},
+      {"sdaccel", kDLOpenCL},
+      {"metal", kDLMetal},
+  };
+  int32_t dtype_code_counter = kMLCExtension_DLDataTypeCode_End;
+  int32_t device_type_code_counter = kMLCExtension_DLDeviceType_End;
   ResourcePool pool;
 
   MLCTypeInfo *GetTypeInfo(int32_t type_index) {
@@ -346,7 +468,7 @@ struct TypeTable {
     return info;
   }
 
-  void SetFunc(const char *name, FuncObj *func, bool allow_override) {
+  void SetFunc(const char *name, FuncObj *func, bool allow_override = false) {
     auto [it, success] = this->global_funcs.try_emplace(std::string(name), nullptr);
     if (!success && !allow_override) {
       MLC_THROW(KeyError) << "Global function already registered: " << name;
@@ -390,67 +512,170 @@ struct TypeTable {
     }
     it->second = std::make_unique<DSOLibrary>(name);
   }
-};
 
-struct _POD_REG {
-  inline static const int32_t _none = //
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCNone))
-          .MemFn("__str__", &::mlc::base::TypeTraits<std::nullptr_t>::__str__);
-  inline static const int32_t _int = //
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCInt))
-          .StaticFn("__init__", [](AnyView value) { return value.operator int64_t(); })
-          .StaticFn("__new_ref__",
-                    [](void *dst, Optional<int64_t> value) { *reinterpret_cast<Optional<int64_t> *>(dst) = value; })
-          .MemFn("__str__", &::mlc::base::TypeTraits<int64_t>::__str__);
-  inline static const int32_t _float =
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCFloat))
-          .StaticFn("__new_ref__",
-                    [](void *dst, Optional<double> value) { *reinterpret_cast<Optional<double> *>(dst) = value; })
-          .MemFn("__str__", &::mlc::base::TypeTraits<double>::__str__);
-  inline static const int32_t _ptr =
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCPtr))
-          .StaticFn("__new_ref__",
-                    [](void *dst, Optional<void *> value) { *reinterpret_cast<Optional<void *> *>(dst) = value; })
-          .MemFn("__str__", &::mlc::base::TypeTraits<void *>::__str__);
-  inline static const int32_t _device =
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCDevice))
-          .StaticFn("__init__", [](AnyView device) { return device.operator DLDevice(); })
-          .StaticFn("__new_ref__",
-                    [](void *dst, Optional<DLDevice> value) { *reinterpret_cast<Optional<DLDevice> *>(dst) = value; })
-          .MemFn("__str__", &::mlc::base::TypeTraits<DLDevice>::__str__);
-  inline static const int32_t _dtype =
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCDataType))
-          .StaticFn("__init__", [](AnyView dtype) { return dtype.operator DLDataType(); })
-          .StaticFn(
-              "__new_ref__",
-              [](void *dst, Optional<DLDataType> value) { *reinterpret_cast<Optional<DLDataType> *>(dst) = value; })
-          .MemFn("__str__", &::mlc::base::TypeTraits<DLDataType>::__str__);
-  inline static const int32_t _str = //
-      ::mlc::core::_Reflect(static_cast<int32_t>(MLCTypeIndex::kMLCRawStr))
-          .MemFn("__str__", &::mlc::base::TypeTraits<const char *>::__str__);
+  void *DeviceTypeToStr(int32_t device_type) const {
+    auto it = this->device_type_code_to_str.find(device_type);
+    const char *ret = it == this->device_type_code_to_str.end() ? "unknown" : it->second.c_str();
+    return const_cast<char *>(ret);
+  }
+
+  int32_t DeviceTypeFromStr(const char *str) const {
+    auto it = this->device_type_str_to_code.find(str);
+    return it == this->device_type_str_to_code.end() ? -1 : it->second;
+  }
+
+  void *DataTypeCodeToStr(int32_t dtype_code) const {
+    auto it = this->dtype_code_to_str.find(dtype_code);
+    const char *ret = it == this->dtype_code_to_str.end() ? "unknown" : it->second.c_str();
+    return const_cast<char *>(ret);
+  }
+
+  DLDataType DataTypeFromStr(const char *str) const {
+    constexpr int64_t u16_max = 65535;
+    constexpr int64_t u8_max = 255;
+    const auto &preset = this->dtype_presets;
+    std::string source = str;
+    if (auto it = preset.find(source); it != preset.end()) {
+      return it->second;
+    }
+    try {
+      int64_t dtype_lanes = 1;
+      std::string dtype_str;
+      if (size_t x_pos = source.rfind('x'); x_pos != std::string::npos) {
+        dtype_str = source.substr(0, x_pos);
+        dtype_lanes = ::mlc::base::StrToInt(source, x_pos + 1);
+        if (dtype_lanes < 0 || dtype_lanes > u16_max) {
+          throw std::runtime_error("Invalid DLDataType");
+        }
+      } else {
+        dtype_str = source;
+      }
+      if (auto it = preset.find(dtype_str); it != preset.end()) {
+        DLDataType dtype = it->second;
+        dtype.lanes = static_cast<uint16_t>(dtype_lanes);
+        return dtype;
+      }
+#define MLC_DTYPE_PARSE_(str, prefix, prefix_len, dtype_code)                                                          \
+  if (str.length() >= prefix_len && str.compare(0, prefix_len, prefix) == 0) {                                         \
+    int64_t dtype_bits = ::mlc::base::StrToInt(str, prefix_len);                                                       \
+    if (dtype_bits < 0 || dtype_bits > u8_max) {                                                                       \
+      throw std::runtime_error("Invalid DLDataType");                                                                  \
+    }                                                                                                                  \
+    return {static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), static_cast<uint16_t>(dtype_lanes)};   \
+  }
+      MLC_DTYPE_PARSE_(dtype_str, "int", 3, kDLInt)
+      MLC_DTYPE_PARSE_(dtype_str, "uint", 4, kDLUInt)
+      MLC_DTYPE_PARSE_(dtype_str, "float", 5, kDLFloat)
+      MLC_DTYPE_PARSE_(dtype_str, "ptr", 3, kDLOpaqueHandle)
+      MLC_DTYPE_PARSE_(dtype_str, "bfloat", 6, kDLBfloat)
+      MLC_DTYPE_PARSE_(dtype_str, "complex", 7, kDLComplex)
+#undef MLC_DTYPE_PARSE_
+    } catch (...) {
+    }
+    MLC_THROW(ValueError) << "Cannot convert to `dtype` from string: " << source;
+    MLC_UNREACHABLE();
+  }
+
+  int32_t DataTypeRegister(const char *name, int32_t dtype_bits) {
+    int32_t dtype_code = ++this->dtype_code_counter;
+    this->dtype_presets[name] = {static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), 1};
+    this->dtype_code_to_str[dtype_code] = name;
+    this->dtype_code_from_str[name] = dtype_code;
+    return dtype_code;
+  }
+
+  int32_t DeviceTypeRegister(const char *name) {
+    int32_t device_type = ++this->device_type_code_counter;
+    this->device_type_code_to_str[device_type] = name;
+    this->device_type_str_to_code[name] = device_type;
+    return device_type;
+  }
 };
 
 inline TypeTable *TypeTable::New() {
+#define MLC_TYPE_TABLE_INIT_TYPE_BEGIN(UnderlyingType, Self)                                                           \
+  {                                                                                                                    \
+    using Traits = TypeTraits<UnderlyingType>;                                                                         \
+    Self->TypeRegister(-1, Traits::type_index, Traits::type_str);                                                      \
+    auto method_static = [self = Self](const char *name, Func func) {                                                  \
+      self->AddMethod(Traits::type_index, MLCTypeMethod{name, reinterpret_cast<MLCFunc *>(func.get()), 1});            \
+    };                                                                                                                 \
+    auto method_member = [self = Self](const char *name, Func func) {                                                  \
+      self->AddMethod(Traits::type_index, MLCTypeMethod{name, reinterpret_cast<MLCFunc *>(func.get()), 0});            \
+    };                                                                                                                 \
+    (void)method_static;                                                                                               \
+    (void)method_member;
+
+#define MLC_TYPE_TABLE_INIT_TYPE_END() }
+
+  using namespace mlc::base;
   TypeTable *self = new TypeTable();
   self->type_table.resize(1024);
   self->type_key_to_info.reserve(1024);
   self->num_types = static_cast<int32_t>(MLCTypeIndex::kMLCDynObjectBegin);
-#define MLC_TYPE_TABLE_INIT_TYPE(UnderlyingType, Self)                                                                 \
-  {                                                                                                                    \
-    using Traits = ::mlc::base::TypeTraits<UnderlyingType>;                                                            \
-    MLCTypeInfo *info = Self->TypeRegister(-1, Traits::type_index, Traits::type_str);                                  \
-    (void)info;                                                                                                        \
-  }
-  MLC_TYPE_TABLE_INIT_TYPE(std::nullptr_t, self);
-  MLC_TYPE_TABLE_INIT_TYPE(int64_t, self);
-  MLC_TYPE_TABLE_INIT_TYPE(double, self);
-  MLC_TYPE_TABLE_INIT_TYPE(void *, self);
-  MLC_TYPE_TABLE_INIT_TYPE(DLDevice, self);
-  MLC_TYPE_TABLE_INIT_TYPE(DLDataType, self);
-  MLC_TYPE_TABLE_INIT_TYPE(const char *, self);
-#undef MLC_TYPE_TABLE_INIT_TYPE
+  self->SetFunc("mlc.ffi.LoadDSO", //
+                Func([self](std::string name) { self->LoadDSO(name); }).get());
+  self->SetFunc("mlc.base.DeviceTypeToStr",
+                Func([self](int32_t device_type) { return self->DeviceTypeToStr(device_type); }).get());
+  self->SetFunc("mlc.base.DeviceTypeFromStr",
+                Func([self](const char *str) { return self->DeviceTypeFromStr(str); }).get());
+  self->SetFunc("mlc.base.DataTypeRegister", Func([self](const char *name, int32_t dtype_bits) {
+                                               return self->DataTypeRegister(name, dtype_bits);
+                                             }).get());
+  self->SetFunc("mlc.base.DataTypeCodeToStr",
+                Func([self](int32_t dtype_code) { return self->DataTypeCodeToStr(dtype_code); }).get());
+  self->SetFunc("mlc.base.DataTypeFromStr", //
+                Func([self](const char *str) { return self->DataTypeFromStr(str); }).get());
+  self->SetFunc("mlc.base.DeviceTypeRegister",
+                Func([self](const char *name) { return self->DeviceTypeRegister(name); }).get());
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(std::nullptr_t, self);
+  method_member("__str__", &TypeTraits<std::nullptr_t>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(int64_t, self);
+  method_static("__init__", [](AnyView value) { return value.operator int64_t(); });
+  method_static("__new_ref__",
+                [](void *dst, Optional<int64_t> value) { *reinterpret_cast<Optional<int64_t> *>(dst) = value; });
+  method_member("__str__", &TypeTraits<int64_t>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(double, self);
+  method_static("__init__", [](AnyView value) { return value.operator double(); });
+  method_static("__new_ref__",
+                [](void *dst, Optional<double> value) { *reinterpret_cast<Optional<double> *>(dst) = value; });
+  method_member("__str__", &TypeTraits<double>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(void *, self);
+  method_static("__init__", [](AnyView value) { return value.operator void *(); });
+  method_static("__new_ref__",
+                [](void *dst, Optional<void *> value) { *reinterpret_cast<Optional<void *> *>(dst) = value; });
+  method_member("__str__", &TypeTraits<void *>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(DLDevice, self);
+  method_static("__init__", [](AnyView device) { return device.operator DLDevice(); });
+  method_static("__new_ref__",
+                [](void *dst, Optional<DLDevice> value) { *reinterpret_cast<Optional<DLDevice> *>(dst) = value; });
+  method_member("__str__", &TypeTraits<DLDevice>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(DLDataType, self);
+  method_static("__init__", [](AnyView dtype) { return dtype.operator DLDataType(); });
+  method_static("__new_ref__",
+                [](void *dst, Optional<DLDataType> value) { *reinterpret_cast<Optional<DLDataType> *>(dst) = value; });
+  method_member("__str__", &TypeTraits<DLDataType>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
+  MLC_TYPE_TABLE_INIT_TYPE_BEGIN(const char *, self);
+  method_member("__str__", &TypeTraits<const char *>::__str__);
+  MLC_TYPE_TABLE_INIT_TYPE_END()
+
   return self;
 }
+#undef MLC_TYPE_TABLE_INIT_TYPE_BEGIN
+#undef MLC_TYPE_TABLE_INIT_TYPE_END
 
 inline void VTable::Set(int32_t type_index, FuncObj *func, int32_t override_mode) {
   auto [it, success] = this->data.try_emplace(type_index, nullptr);

--- a/include/mlc/base/lib.h
+++ b/include/mlc/base/lib.h
@@ -11,6 +11,12 @@ struct Lib {
   static ::mlc::Str CxxStr(AnyView obj);
   static ::mlc::Str Str(AnyView obj);
   static Any IRPrint(AnyView obj, AnyView printer, AnyView path);
+  static const char *DeviceTypeToStr(int32_t device_type);
+  static int32_t DeviceTypeFromStr(const char *source);
+  static void DeviceTypeRegister(const char *name);
+  static const char *DataTypeCodeToStr(int32_t dtype_code);
+  static DLDataType DataTypeFromStr(const char *source);
+  static void DataTypeRegister(const char *name, int32_t dtype_bits);
 
   static FuncObj *_init(int32_t type_index) { return VTableGetFunc(init, type_index, "__init__"); }
   MLC_INLINE static MLCTypeInfo *GetTypeInfo(int32_t type_index) {

--- a/include/mlc/base/traits_device.h
+++ b/include/mlc/base/traits_device.h
@@ -1,15 +1,16 @@
 #ifndef MLC_BASE_TRAITS_DEVICE_H_
 #define MLC_BASE_TRAITS_DEVICE_H_
 
+#include "./lib.h"
 #include "./utils.h"
-#include <unordered_map>
 
 namespace mlc {
 namespace base {
 
-const char *DLDeviceType2Str(DLDeviceType type);
-DLDevice String2DLDevice(const std::string &source);
+DLDevice DeviceFromStr(const std::string &source);
+
 inline bool DeviceEqual(DLDevice a, DLDevice b) { return a.device_type == b.device_type && a.device_id == b.device_id; }
+inline const char *DeviceType2Str(int32_t device_type) { return ::mlc::Lib::DeviceTypeToStr(device_type); }
 
 template <> struct TypeTraits<DLDevice> {
   static constexpr int32_t type_index = static_cast<int32_t>(MLCTypeIndex::kMLCDevice);
@@ -26,10 +27,10 @@ template <> struct TypeTraits<DLDevice> {
       return v->v.v_device;
     }
     if (ty == MLCTypeIndex::kMLCRawStr) {
-      return String2DLDevice(v->v.v_str);
+      return DeviceFromStr(v->v.v_str);
     }
     if (ty == MLCTypeIndex::kMLCStr) {
-      return String2DLDevice(reinterpret_cast<const MLCStr *>(v->v.v_obj)->data);
+      return DeviceFromStr(reinterpret_cast<const MLCStr *>(v->v.v_obj)->data);
     }
     throw TemporaryTypeError();
   }
@@ -38,87 +39,27 @@ template <> struct TypeTraits<DLDevice> {
 
   MLC_INLINE static std::string __str__(DLDevice device) {
     std::ostringstream os;
-    os << DLDeviceType2Str(static_cast<DLDeviceType>(device.device_type)) << ":" << device.device_id;
+    os << DeviceType2Str(static_cast<DLDeviceType>(device.device_type)) << ":" << device.device_id;
     return os.str();
   }
-
-  static inline MLC_SYMBOL_HIDE std::unordered_map<std::string, DLDeviceType> str2device_type = {
-      {"cpu", kDLCPU},
-      {"cuda", kDLCUDA},
-      {"cuda_host", kDLCUDAHost},
-      {"opencl", kDLOpenCL},
-      {"vulkan", kDLVulkan},
-      {"mps", kDLMetal},
-      {"vpi", kDLVPI},
-      {"rocm", kDLROCM},
-      {"rocm_host", kDLROCMHost},
-      {"ext_dev", kDLExtDev},
-      {"cuda_managed", kDLCUDAManaged},
-      {"oneapi", kDLOneAPI},
-      {"webgpu", kDLWebGPU},
-      {"hexagon", kDLHexagon},
-      {"maia", kDLMAIA},
-      // aliases
-      {"llvm", kDLCPU},
-      {"nvptx", kDLCUDA},
-      {"cl", kDLOpenCL},
-      {"sdaccel", kDLOpenCL},
-      {"metal", kDLMetal},
-  };
 };
 
-MLC_INLINE const char *DLDeviceType2Str(DLDeviceType type) {
-  switch (type) {
-  case kDLCPU:
-    return "cpu";
-  case kDLCUDA:
-    return "cuda";
-  case kDLCUDAHost:
-    return "cuda_host";
-  case kDLOpenCL:
-    return "opencl";
-  case kDLVulkan:
-    return "vulkan";
-  case kDLMetal:
-    return "mps";
-  case kDLVPI:
-    return "vpi";
-  case kDLROCM:
-    return "rocm";
-  case kDLROCMHost:
-    return "rocm_host";
-  case kDLExtDev:
-    return "ext_dev";
-  case kDLCUDAManaged:
-    return "cuda_managed";
-  case kDLOneAPI:
-    return "oneapi";
-  case kDLWebGPU:
-    return "webgpu";
-  case kDLHexagon:
-    return "hexagon";
-  case kDLMAIA:
-    return "maia";
-  }
-  return "unknown";
-}
-
-inline DLDevice String2DLDevice(const std::string &source) {
+inline DLDevice DeviceFromStr(const std::string &source) {
   constexpr int64_t i32_max = 2147483647;
-  using Traits = TypeTraits<DLDevice>;
-  DLDeviceType device_type;
+  int32_t device_type;
   int64_t device_id = 0;
   try {
     if (size_t c_pos = source.rfind(':'); c_pos != std::string::npos) {
-      device_type = Traits::str2device_type.at(source.substr(0, c_pos));
+      device_type = ::mlc::Lib::DeviceTypeFromStr(source.substr(0, c_pos).c_str());
       device_id = StrToInt(source, c_pos + 1);
     } else {
-      device_type = Traits::str2device_type.at(source);
+      device_type = ::mlc::Lib::DeviceTypeFromStr(source.c_str());
+      device_id = 0;
     }
-    if (device_id < 0 || device_id > i32_max) {
-      throw std::runtime_error("Invalid device id");
+    if (device_type < 0 || device_id < 0 || device_id > i32_max) {
+      throw std::runtime_error(""); // Going to catch it below
     }
-    return DLDevice{device_type, static_cast<int32_t>(device_id)};
+    return DLDevice{static_cast<DLDeviceType>(device_type), static_cast<int32_t>(device_id)};
   } catch (...) {
   }
   MLC_THROW(ValueError) << "Cannot convert to `Device` from string: " << source;

--- a/include/mlc/base/traits_dtype.h
+++ b/include/mlc/base/traits_dtype.h
@@ -1,18 +1,18 @@
 #ifndef MLC_BASE_TRAITS_DTYPE_H_
 #define MLC_BASE_TRAITS_DTYPE_H_
 
+#include "./lib.h"
 #include "./utils.h"
-#include <cstdlib>
-#include <unordered_map>
 
 namespace mlc {
 namespace base {
 
-inline const char *DLDataTypeCode2Str(int32_t type_code);
-inline DLDataType String2DLDataType(const std::string &source);
+inline DLDataType DataTypeFromStr(const char *source);
+
 inline bool DataTypeEqual(DLDataType a, DLDataType b) {
   return a.code == b.code && a.bits == b.bits && a.lanes == b.lanes;
 }
+inline const char *DataTypeCode2Str(int32_t type_code) { return ::mlc::Lib::DataTypeCodeToStr(type_code); }
 
 template <> struct TypeTraits<DLDataType> {
   static constexpr int32_t type_index = static_cast<int32_t>(MLCTypeIndex::kMLCDataType);
@@ -29,10 +29,10 @@ template <> struct TypeTraits<DLDataType> {
       return v->v.v_dtype;
     }
     if (ty == MLCTypeIndex::kMLCRawStr) {
-      return String2DLDataType(v->v.v_str);
+      return DataTypeFromStr(v->v.v_str);
     }
     if (ty == MLCTypeIndex::kMLCStr) {
-      return String2DLDataType(reinterpret_cast<const MLCStr *>(v->v.v_obj)->data);
+      return DataTypeFromStr(reinterpret_cast<const MLCStr *>(v->v.v_obj)->data);
     }
     throw TemporaryTypeError();
   }
@@ -50,8 +50,9 @@ template <> struct TypeTraits<DLDataType> {
       return "void";
     }
     std::ostringstream os;
-    os << DLDataTypeCode2Str(code);
-    if (code != kDLDataTypeFloat8E5M2 && code != kDLDataTypeFloat8E4M3FN) {
+    os << DataTypeCode2Str(code);
+    if (code < kMLCExtension_DLDataTypeCode_Begin) {
+      // for `code >= kMLCExtension_DLDataTypeCode_Begin`, the `bits` is already encoded in `code`
       os << bits;
     }
     if (lanes != 1) {
@@ -59,98 +60,9 @@ template <> struct TypeTraits<DLDataType> {
     }
     return os.str();
   }
-
-  static inline MLC_SYMBOL_HIDE std::unordered_map<std::string, DLDataType> preset = {
-      {"void", {kDLOpaqueHandle, 0, 0}},
-      {"bool", {kDLUInt, 1, 1}},
-      {"int4", {kDLInt, 4, 1}},
-      {"int8", {kDLInt, 8, 1}},
-      {"int16", {kDLInt, 16, 1}},
-      {"int32", {kDLInt, 32, 1}},
-      {"int64", {kDLInt, 64, 1}},
-      {"uint4", {kDLUInt, 4, 1}},
-      {"uint8", {kDLUInt, 8, 1}},
-      {"uint16", {kDLUInt, 16, 1}},
-      {"uint32", {kDLUInt, 32, 1}},
-      {"uint64", {kDLUInt, 64, 1}},
-      {"float8_e4m3fn", {kDLDataTypeFloat8E4M3FN, 8, 1}},
-      {"float8_e5m2", {kDLDataTypeFloat8E5M2, 8, 1}},
-      {"float16", {kDLFloat, 16, 1}},
-      {"float32", {kDLFloat, 32, 1}},
-      {"float64", {kDLFloat, 64, 1}},
-      {"bfloat16", {kDLBfloat, 16, 1}},
-  };
 };
 
-MLC_INLINE const char *DLDataTypeCode2Str(int32_t type_code) {
-  switch (type_code) {
-  case kDLInt:
-    return "int";
-  case kDLUInt:
-    return "uint";
-  case kDLFloat:
-    return "float";
-  case kDLOpaqueHandle:
-    return "ptr";
-  case kDLBfloat:
-    return "bfloat";
-  case kDLComplex:
-    return "complex";
-  case kDLBool:
-    return "bool";
-  case kDLDataTypeFloat8E4M3FN:
-    return "float8_e4m3fn";
-  case kDLDataTypeFloat8E5M2:
-    return "float8_e5m2";
-  }
-  return "unknown";
-}
-
-inline DLDataType String2DLDataType(const std::string &source) {
-  constexpr int64_t u16_max = 65535;
-  constexpr int64_t u8_max = 255;
-  using Traits = TypeTraits<DLDataType>;
-  if (auto it = Traits::preset.find(source); it != Traits::preset.end()) {
-    return it->second;
-  }
-  try {
-    int64_t dtype_lanes = 1;
-    std::string dtype_str;
-    if (size_t x_pos = source.rfind('x'); x_pos != std::string::npos) {
-      dtype_str = source.substr(0, x_pos);
-      dtype_lanes = StrToInt(source, x_pos + 1);
-      if (dtype_lanes < 0 || dtype_lanes > u16_max) {
-        throw std::runtime_error("Invalid DLDataType");
-      }
-    } else {
-      dtype_str = source;
-    }
-    if (dtype_str == "float8_e4m3fn") {
-      return {static_cast<uint8_t>(kDLDataTypeFloat8E4M3FN), 8, static_cast<uint16_t>(dtype_lanes)};
-    }
-    if (dtype_str == "float8_e5m2") {
-      return {static_cast<uint8_t>(kDLDataTypeFloat8E5M2), 8, static_cast<uint16_t>(dtype_lanes)};
-    }
-#define MLC_DTYPE_PARSE_(str, prefix, prefix_len, dtype_code)                                                          \
-  if (str.length() >= prefix_len && str.compare(0, prefix_len, prefix) == 0) {                                         \
-    int64_t dtype_bits = StrToInt(str, prefix_len);                                                                    \
-    if (dtype_bits < 0 || dtype_bits > u8_max) {                                                                       \
-      throw std::runtime_error("Invalid DLDataType");                                                                  \
-    }                                                                                                                  \
-    return {static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), static_cast<uint16_t>(dtype_lanes)};   \
-  }
-    MLC_DTYPE_PARSE_(dtype_str, "int", 3, kDLInt)
-    MLC_DTYPE_PARSE_(dtype_str, "uint", 4, kDLUInt)
-    MLC_DTYPE_PARSE_(dtype_str, "float", 5, kDLFloat)
-    MLC_DTYPE_PARSE_(dtype_str, "ptr", 3, kDLOpaqueHandle)
-    MLC_DTYPE_PARSE_(dtype_str, "bfloat", 6, kDLBfloat)
-    MLC_DTYPE_PARSE_(dtype_str, "complex", 7, kDLComplex)
-#undef MLC_DTYPE_PARSE_
-  } catch (...) {
-  }
-  MLC_THROW(ValueError) << "Cannot convert to `dtype` from string: " << source;
-  MLC_UNREACHABLE();
-}
+inline DLDataType DataTypeFromStr(const char *source) { return ::mlc::Lib::DataTypeFromStr(source); }
 
 } // namespace base
 } // namespace mlc

--- a/include/mlc/c_api.h
+++ b/include/mlc/c_api.h
@@ -30,11 +30,30 @@
 extern "C" {
 #endif
 
-typedef enum {
-  // TODO: 1) add complete set of fp8 support; 2) allow more flexible dtype definition
-  kDLDataTypeFloat8E4M3FN = 7,
-  kDLDataTypeFloat8E5M2 = 8,
-} DLDataTypeCodeExtension;
+typedef enum { // ranged [0, 2 ** 8)
+  kMLCExtension_DLDataTypeCode_Begin = 7,
+  // 8-bit floating point representations
+  kDLDataTypeFloat8Begin = 7,
+  kDLDataTypeFloat8E3M4 = 7,
+  kDLDataTypeFloat8E4M3 = 8,
+  kDLDataTypeFloat8E4M3B11FNUZ = 9,
+  kDLDataTypeFloat8E4M3FN = 10,
+  kDLDataTypeFloat8E4M3FNUZ = 11,
+  kDLDataTypeFloat8E5M2 = 12,
+  kDLDataTypeFloat8E5M2FNUZ = 13,
+  kDLDataTypeFloat8E8M0FNU = 14,
+  kDLDataTypeFloat8End = 15,
+  // Microscaling (MX) sub-byte floating point representations
+  kDLDataTypeFloat4E2M1FN = 15, // higher 4 bits are unused
+  kDLDataTypeFloat6E2M3FN = 16, // higher 2 bits are unused
+  kDLDataTypeFloat6E3M2FN = 17, // higher 2 bits are unused
+  kMLCExtension_DLDataTypeCode_End = kDLDataTypeFloat6E3M2FN,
+} MLCExtension_DLDataTypeCode;
+
+typedef enum { // ranged [0, 2 ** 32)
+  kMLCExtension_DLDeviceType_Begin = 18,
+  kMLCExtension_DLDeviceType_End = kMLCExtension_DLDeviceType_Begin,
+} MLCExtension_DLDeviceType;
 
 #ifdef __cplusplus
 enum MLCTypeIndex : int32_t {

--- a/include/mlc/core/all.h
+++ b/include/mlc/core/all.h
@@ -154,6 +154,49 @@ inline FuncObj *Lib::FuncGetGlobal(const char *name, bool allow_missing) {
   }
   return ret;
 }
+inline const char *Lib::DeviceTypeToStr(int32_t device_type) {
+  static FuncObj *func_device_type2str = ::mlc::Lib::FuncGetGlobal("mlc.base.DeviceTypeToStr");
+  AnyView arg(device_type);
+  Any ret;
+  ::mlc::base::FuncCall(func_device_type2str, 1, &arg, &ret);
+  void *ptr = ret;
+  return static_cast<const char *>(ptr);
+}
+inline int32_t Lib::DeviceTypeFromStr(const char *source) {
+  static FuncObj *func_device_type2str = ::mlc::Lib::FuncGetGlobal("mlc.base.DeviceTypeFromStr");
+  AnyView arg(source);
+  Any ret;
+  ::mlc::base::FuncCall(func_device_type2str, 1, &arg, &ret);
+  return ret;
+}
+inline void Lib::DeviceTypeRegister(const char *name) {
+  static FuncObj *func_device_type_register = ::mlc::Lib::FuncGetGlobal("mlc.base.DeviceTypeRegister");
+  AnyView arg(name);
+  Any ret;
+  ::mlc::base::FuncCall(func_device_type_register, 1, &arg, &ret);
+}
+inline const char *Lib::DataTypeCodeToStr(int32_t dtype_code) {
+  static FuncObj *func_dtype_code2str = ::mlc::Lib::FuncGetGlobal("mlc.base.DataTypeCodeToStr");
+  AnyView arg(dtype_code);
+  Any ret;
+  ::mlc::base::FuncCall(func_dtype_code2str, 1, &arg, &ret);
+  void *ptr = ret;
+  return static_cast<const char *>(ptr);
+}
+inline DLDataType Lib::DataTypeFromStr(const char *source) {
+  static FuncObj *func_dtype_from_str = ::mlc::Lib::FuncGetGlobal("mlc.base.DataTypeFromStr");
+  AnyView arg(source);
+  Any ret;
+  ::mlc::base::FuncCall(func_dtype_from_str, 1, &arg, &ret);
+  return ret;
+}
+inline void Lib::DataTypeRegister(const char *name, int32_t dtype_bits) {
+  static FuncObj *func_dtype_register = ::mlc::Lib::FuncGetGlobal("mlc.base.DataTypeRegister");
+  AnyView arg[2]{name, dtype_bits};
+  Any ret;
+  ::mlc::base::FuncCall(func_dtype_register, 2, arg, &ret);
+}
+
 } // namespace mlc
 
 #endif // MLC_CORE_ALL_H_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,17 @@ authors = [{ name = "MLC Authors", email = "junrushao@apache.org" }]
 "mlc.config" = "mlc.config:main"
 
 [project.optional-dependencies]
-tests = ['pytest']
-dev = ["cython>=3", "pre-commit", "pytest", "pipx", "ipdb", "ruff", "mypy"]
+tests = ['pytest', 'torch']
+dev = [
+    "cython>=3",
+    "pre-commit",
+    "pytest",
+    "pipx",
+    "ipdb",
+    "ruff",
+    "mypy",
+    "torch",
+]
 
 [build-system]
 requires = ["scikit-build-core>=0.9.8", "cython"]
@@ -75,7 +84,7 @@ ignore = [
 fixable = ["ALL"]
 unfixable = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 
 [tool.ruff.format]

--- a/python/mlc/_cython/core.pyx
+++ b/python/mlc/_cython/core.pyx
@@ -1279,7 +1279,7 @@ cpdef object error_pycode_fake(str filename, str funcname, int32_t lineno):
 cpdef tuple dtype_as_triple(PyAny obj):
     cdef DLDataType dtype = obj._mlc_any.v.v_dtype
     cdef int32_t code = <int32_t>dtype.code
-    cdef int32_t bits = <int32_t>dtype.code
+    cdef int32_t bits = <int32_t>dtype.bits
     cdef int32_t lanes = <int32_t>dtype.lanes
     return code, bits, lanes
 

--- a/python/mlc/core/device.py
+++ b/python/mlc/core/device.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mlc._cython import DeviceType, PyAny, c_class_core, device_as_pair, device_normalize
+
+if TYPE_CHECKING:
+    import torch
 
 
 @c_class_core("Device")
 class Device(PyAny):
-    def __init__(self, device: str | Device) -> None:
+    def __init__(self, device: str | Device | torch.device) -> None:
         self._mlc_init(device_normalize(device))
 
     @property
@@ -13,8 +18,12 @@ class Device(PyAny):
         return device_as_pair(self)
 
     @property
-    def device_type(self) -> DeviceType:
-        return DeviceType(self._device_pair[0])
+    def device_type(self) -> DeviceType | int:
+        code = self._device_pair[0]
+        try:
+            return DeviceType(code)
+        except ValueError:
+            return code
 
     @property
     def device_id(self) -> int:
@@ -28,3 +37,14 @@ class Device(PyAny):
 
     def __hash__(self) -> int:
         return hash((Device, *self._device_pair))
+
+    def torch(self) -> torch.device:
+        import torch
+
+        return torch.device(str(self))
+
+    @staticmethod
+    def register(name: str) -> int:
+        from .func import Func
+
+        return Func.get("mlc.base.DeviceTypeRegister")(name)

--- a/tests/python/test_core_device.py
+++ b/tests/python/test_core_device.py
@@ -1,5 +1,6 @@
 import mlc
 import pytest
+import torch
 from mlc import Device
 
 
@@ -23,3 +24,40 @@ def test_device_init_fail(x: str) -> None:
         assert str(e) == f"Cannot convert to `Device` from string: {x}"
     else:
         assert False
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        ("meta:0", torch.device("meta")),
+        ("cpu:0", torch.device("cpu")),
+        ("cpu:0", torch.device("cpu:0")),
+        ("cuda:0", torch.device("cuda")),
+        ("cuda:1", torch.device("cuda:1")),
+        ("mps:2", torch.device("mps:2")),
+    ],
+)
+def test_device_from_torch(x: str, y: torch.device) -> None:
+    assert x == str(Device(y))
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        (torch.device("meta:0"), Device("meta")),
+        (torch.device("cpu:0"), Device("cpu")),
+        (torch.device("cpu:0"), Device("cpu:0")),
+        (torch.device("cuda:0"), Device("cuda")),
+        (torch.device("cuda:1"), Device("cuda:1")),
+        (torch.device("mps:2"), Device("mps:2")),
+    ],
+)
+def test_device_to_torch(x: torch.device, y: Device) -> None:
+    assert x == y.torch()
+
+
+def test_device_register() -> None:
+    code = Device.register("my_device")
+    device = Device("my_device:10")
+    assert device.device_type == code and device.device_id == 10
+    assert str(device) == "my_device:10"

--- a/tests/python/test_core_dtype.py
+++ b/tests/python/test_core_dtype.py
@@ -1,5 +1,8 @@
+import ml_dtypes
 import mlc
+import numpy as np
 import pytest
+import torch
 from mlc import DataType
 
 
@@ -21,3 +24,96 @@ def test_dtype_init_fail(x: str) -> None:
         assert str(e) == f"Cannot convert to `dtype` from string: {x}"
     else:
         assert False
+
+
+@pytest.mark.parametrize("x", [DataType("int32"), DataType("int32x3"), DataType("float8")])
+def test_dtype_init_dtype(x: DataType) -> None:
+    y = DataType(x)
+    assert x == y
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        (torch.int32, "int32"),
+        (torch.float16, "float16"),
+        (torch.float8_e4m3fn, "float8_e4m3fn"),
+        (torch.float8_e4m3fnuz, "float8_e4m3fnuz"),
+        (torch.float8_e5m2, "float8_e5m2"),
+        (torch.float8_e5m2fnuz, "float8_e5m2fnuz"),
+    ],
+)
+def test_dtype_init_torch(x: str, y: DataType) -> None:
+    assert y == str(DataType(x))
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        (ml_dtypes.int2, "int2"),
+        (ml_dtypes.int4, "int4"),
+        (ml_dtypes.uint2, "uint2"),
+        (ml_dtypes.uint4, "uint4"),
+        (ml_dtypes.float8_e3m4, "float8_e3m4"),
+        (ml_dtypes.float8_e4m3, "float8_e4m3"),
+        (ml_dtypes.float8_e4m3b11fnuz, "float8_e4m3b11fnuz"),
+        (ml_dtypes.float8_e4m3fn, "float8_e4m3fn"),
+        (ml_dtypes.float8_e4m3fnuz, "float8_e4m3fnuz"),
+        (ml_dtypes.float8_e5m2, "float8_e5m2"),
+        (ml_dtypes.float8_e5m2fnuz, "float8_e5m2fnuz"),
+        (ml_dtypes.float8_e8m0fnu, "float8_e8m0fnu"),
+        (ml_dtypes.float4_e2m1fn, "float4_e2m1fn"),
+        (ml_dtypes.float6_e2m3fn, "float6_e2m3fn"),
+        (ml_dtypes.float6_e3m2fn, "float6_e3m2fn"),
+    ],
+)
+def test_dtype_init_ml_dtypes(x: type, y: str) -> None:
+    assert y == str(DataType(x))
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        ("int32", torch.int32),
+        ("float16", torch.float16),
+        ("float8_e4m3fn", torch.float8_e4m3fn),
+        ("float8_e4m3fnuz", torch.float8_e4m3fnuz),
+        ("float8_e5m2", torch.float8_e5m2),
+        ("float8_e5m2fnuz", torch.float8_e5m2fnuz),
+    ],
+)
+def test_dtype_to_torch(x: str, y: torch.dtype) -> None:
+    assert DataType(x).torch() == y
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        ("int2", ml_dtypes.int2),
+        ("int4", ml_dtypes.int4),
+        ("uint2", ml_dtypes.uint2),
+        ("uint4", ml_dtypes.uint4),
+        ("int32", np.int32),
+        ("float16", np.float16),
+        ("float8_e3m4", ml_dtypes.float8_e3m4),
+        ("float8_e4m3", ml_dtypes.float8_e4m3),
+        ("float8_e4m3b11fnuz", ml_dtypes.float8_e4m3b11fnuz),
+        ("float8_e4m3fn", ml_dtypes.float8_e4m3fn),
+        ("float8_e4m3fnuz", ml_dtypes.float8_e4m3fnuz),
+        ("float8_e5m2", ml_dtypes.float8_e5m2),
+        ("float8_e5m2fnuz", ml_dtypes.float8_e5m2fnuz),
+        ("float8_e8m0fnu", ml_dtypes.float8_e8m0fnu),
+        ("float4_e2m1fn", ml_dtypes.float4_e2m1fn),
+        ("float6_e2m3fn", ml_dtypes.float6_e2m3fn),
+        ("float6_e3m2fn", ml_dtypes.float6_e3m2fn),
+    ],
+)
+def test_dtype_to_numpy(x: str, y: type) -> None:
+    assert DataType(x).numpy() == np.dtype(y)
+
+
+def test_dtype_register() -> None:
+    code = DataType.register("float8_custom", bits=8)
+    dtype = DataType("float8_custom")
+    assert dtype.code == code and dtype.bits == 8 and dtype.lanes == 1
+    assert str(dtype) == "float8_custom"


### PR DESCRIPTION
This commit supports
- dtype conversion: `mlc.DataType` <=> `torch.dtype` <=> `numpy.dtype`
- device conversion: `mlc.Device` <=> `torch.device`.
- dtype registration: `mlc.DataType.register(name: str, bits: int)`
- device registration: `mlc.Device(name: str)`
