### PR TITLE
feat(core): Support Bool in Any/AnyView

### DIFF
--- a/cpp/c_api_tests.cc
+++ b/cpp/c_api_tests.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <mlc/core/all.h>
 
 namespace mlc {
@@ -7,6 +8,7 @@ namespace {
 
 MLC_REGISTER_FUNC("mlc.testing.cxx_none").set_body([]() -> void { return; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_null").set_body([]() -> void * { return nullptr; });
+MLC_REGISTER_FUNC("mlc.testing.cxx_bool").set_body([](bool x) -> bool { return x; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_int").set_body([](int x) -> int { return x; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_float").set_body([](double x) -> double { return x; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_ptr").set_body([](void *x) -> void * { return x; });
@@ -17,6 +19,7 @@ MLC_REGISTER_FUNC("mlc.testing.cxx_raw_str").set_body([](const char *x) { return
 /**************** Reflection ****************/
 
 struct TestingCClassObj : public Object {
+  bool bool_;
   int8_t i8;
   int16_t i16;
   int32_t i32;
@@ -40,6 +43,7 @@ struct TestingCClassObj : public Object {
   Dict<Any, Str> dict_any_str;
   Dict<Str, List<int>> dict_str_list_int;
 
+  Optional<bool> opt_bool;
   Optional<int64_t> opt_i64;
   Optional<double> opt_f64;
   Optional<void *> opt_raw_ptr;
@@ -57,22 +61,22 @@ struct TestingCClassObj : public Object {
   Optional<Dict<Any, Str>> opt_dict_any_str;
   Optional<Dict<Str, List<int>>> opt_dict_str_list_int;
 
-  explicit TestingCClassObj(int8_t i8, int16_t i16, int32_t i32, int64_t i64, float f32, double f64, void *raw_ptr,
-                            DLDataType dtype, DLDevice device, Any any, Func func, UList ulist, UDict udict, Str str_,
-                            Str str_readonly, List<Any> list_any, List<List<int>> list_list_int,
+  explicit TestingCClassObj(bool bool_, int8_t i8, int16_t i16, int32_t i32, int64_t i64, float f32, double f64,
+                            void *raw_ptr, DLDataType dtype, DLDevice device, Any any, Func func, UList ulist,
+                            UDict udict, Str str_, Str str_readonly, List<Any> list_any, List<List<int>> list_list_int,
                             Dict<Any, Any> dict_any_any, Dict<Str, Any> dict_str_any, Dict<Any, Str> dict_any_str,
-                            Dict<Str, List<int>> dict_str_list_int, Optional<int64_t> opt_i64, Optional<double> opt_f64,
-                            Optional<void *> opt_raw_ptr, Optional<DLDataType> opt_dtype, Optional<DLDevice> opt_device,
-                            Optional<Func> opt_func, Optional<UList> opt_ulist, Optional<UDict> opt_udict,
-                            Optional<Str> opt_str, Optional<List<Any>> opt_list_any,
+                            Dict<Str, List<int>> dict_str_list_int, Optional<bool> opt_bool, Optional<int64_t> opt_i64,
+                            Optional<double> opt_f64, Optional<void *> opt_raw_ptr, Optional<DLDataType> opt_dtype,
+                            Optional<DLDevice> opt_device, Optional<Func> opt_func, Optional<UList> opt_ulist,
+                            Optional<UDict> opt_udict, Optional<Str> opt_str, Optional<List<Any>> opt_list_any,
                             Optional<List<List<int>>> opt_list_list_int, Optional<Dict<Any, Any>> opt_dict_any_any,
                             Optional<Dict<Str, Any>> opt_dict_str_any, Optional<Dict<Any, Str>> opt_dict_any_str,
                             Optional<Dict<Str, List<int>>> opt_dict_str_list_int)
-      : i8(i8), i16(i16), i32(i32), i64(i64), f32(f32), f64(f64), raw_ptr(raw_ptr), dtype(dtype), device(device),
-        any(any), func(func), ulist(ulist), udict(udict), str_(str_), str_readonly(str_readonly), list_any(list_any),
-        list_list_int(list_list_int), dict_any_any(dict_any_any), dict_str_any(dict_str_any),
-        dict_any_str(dict_any_str), dict_str_list_int(dict_str_list_int), opt_i64(opt_i64), opt_f64(opt_f64),
-        opt_raw_ptr(opt_raw_ptr), opt_dtype(opt_dtype), opt_device(opt_device), opt_func(opt_func),
+      : bool_(bool_), i8(i8), i16(i16), i32(i32), i64(i64), f32(f32), f64(f64), raw_ptr(raw_ptr), dtype(dtype),
+        device(device), any(any), func(func), ulist(ulist), udict(udict), str_(str_), str_readonly(str_readonly),
+        list_any(list_any), list_list_int(list_list_int), dict_any_any(dict_any_any), dict_str_any(dict_str_any),
+        dict_any_str(dict_any_str), dict_str_list_int(dict_str_list_int), opt_bool(opt_bool), opt_i64(opt_i64),
+        opt_f64(opt_f64), opt_raw_ptr(opt_raw_ptr), opt_dtype(opt_dtype), opt_device(opt_device), opt_func(opt_func),
         opt_ulist(opt_ulist), opt_udict(opt_udict), opt_str(opt_str), opt_list_any(opt_list_any),
         opt_list_list_int(opt_list_list_int), opt_dict_any_any(opt_dict_any_any), opt_dict_str_any(opt_dict_str_any),
         opt_dict_any_str(opt_dict_any_str), opt_dict_str_list_int(opt_dict_str_list_int) {}
@@ -84,6 +88,7 @@ struct TestingCClassObj : public Object {
 
 struct TestingCClass : public ObjectRef {
   MLC_DEF_OBJ_REF(MLC_EXPORTS, TestingCClass, TestingCClassObj, ObjectRef)
+      .Field("bool_", &TestingCClassObj::bool_)
       .Field("i8", &TestingCClassObj::i8)
       .Field("i16", &TestingCClassObj::i16)
       .Field("i32", &TestingCClassObj::i32)
@@ -105,6 +110,7 @@ struct TestingCClass : public ObjectRef {
       .Field("dict_str_any", &TestingCClassObj::dict_str_any)
       .Field("dict_any_str", &TestingCClassObj::dict_any_str)
       .Field("dict_str_list_int", &TestingCClassObj::dict_str_list_int)
+      .Field("opt_bool", &TestingCClassObj::opt_bool)
       .Field("opt_i64", &TestingCClassObj::opt_i64)
       .Field("opt_f64", &TestingCClassObj::opt_f64)
       .Field("opt_raw_ptr", &TestingCClassObj::opt_raw_ptr)
@@ -121,13 +127,13 @@ struct TestingCClass : public ObjectRef {
       .Field("opt_dict_any_str", &TestingCClassObj::opt_dict_any_str)
       .Field("opt_dict_str_list_int", &TestingCClassObj::opt_dict_str_list_int)
       .MemFn("i64_plus_one", &TestingCClassObj::i64_plus_one)
-      .StaticFn("__init__",
-                InitOf<TestingCClassObj, int8_t, int16_t, int32_t, int64_t, float, double, void *, DLDataType, DLDevice,
-                       Any, Func, UList, UDict, Str, Str, List<Any>, List<List<int>>, Dict<Any, Any>, Dict<Str, Any>,
-                       Dict<Any, Str>, Dict<Str, List<int>>, Optional<int64_t>, Optional<double>, Optional<void *>,
-                       Optional<DLDataType>, Optional<DLDevice>, Optional<Func>, Optional<UList>, Optional<UDict>,
-                       Optional<Str>, Optional<List<Any>>, Optional<List<List<int>>>, Optional<Dict<Any, Any>>,
-                       Optional<Dict<Str, Any>>, Optional<Dict<Any, Str>>, Optional<Dict<Str, List<int>>>>);
+      .StaticFn("__init__", InitOf<TestingCClassObj, bool, int8_t, int16_t, int32_t, int64_t, float, double, void *,
+                                   DLDataType, DLDevice, Any, Func, UList, UDict, Str, Str, List<Any>, List<List<int>>,
+                                   Dict<Any, Any>, Dict<Str, Any>, Dict<Any, Str>, Dict<Str, List<int>>, Optional<bool>,
+                                   Optional<int64_t>, Optional<double>, Optional<void *>, Optional<DLDataType>,
+                                   Optional<DLDevice>, Optional<Func>, Optional<UList>, Optional<UDict>, Optional<Str>,
+                                   Optional<List<Any>>, Optional<List<List<int>>>, Optional<Dict<Any, Any>>,
+                                   Optional<Dict<Str, Any>>, Optional<Dict<Any, Str>>, Optional<Dict<Str, List<int>>>>);
 };
 
 /**************** Traceback ****************/
@@ -188,6 +194,141 @@ MLC_REGISTER_FUNC("mlc.testing.nested_type_checking_list").set_body([](Str name)
     using Type = Dict<Str, List<int>>;
     return Func([](Type v) { return v; });
   }
+  MLC_UNREACHABLE();
+});
+
+/**************** Visitor ****************/
+
+MLC_REGISTER_FUNC("mlc.testing.VisitFields").set_body([](ObjectRef root) {
+  struct Visitor {
+    void operator()(MLCTypeField *f, const Any *any) { Push("Any", f->name, *any); }
+    void operator()(MLCTypeField *f, ObjectRef *obj) { Push("ObjectRef", f->name, *obj); }
+    void operator()(MLCTypeField *f, Optional<ObjectRef> *opt) { Push("Optional<ObjectRef>", f->name, *opt); }
+    void operator()(MLCTypeField *f, Optional<bool> *opt) { Push("Optional<bool>", f->name, *opt); }
+    void operator()(MLCTypeField *f, Optional<int64_t> *opt) { Push("Optional<int64_t>", f->name, *opt); }
+    void operator()(MLCTypeField *f, Optional<double> *opt) { Push("Optional<double>", f->name, *opt); }
+    void operator()(MLCTypeField *f, Optional<DLDevice> *opt) { Push("Optional<DLDevice>", f->name, *opt); }
+    void operator()(MLCTypeField *f, Optional<DLDataType> *opt) { Push("Optional<DLDataType>", f->name, *opt); }
+    void operator()(MLCTypeField *f, bool *v) { Push("bool", f->name, *v); }
+    void operator()(MLCTypeField *f, int8_t *v) { Push("int8_t", f->name, *v); }
+    void operator()(MLCTypeField *f, int16_t *v) { Push("int16_t", f->name, *v); }
+    void operator()(MLCTypeField *f, int32_t *v) { Push("int32_t", f->name, *v); }
+    void operator()(MLCTypeField *f, int64_t *v) { Push("int64_t", f->name, *v); }
+    void operator()(MLCTypeField *f, float *v) { Push("float", f->name, *v); }
+    void operator()(MLCTypeField *f, double *v) { Push("double", f->name, *v); }
+    void operator()(MLCTypeField *f, DLDataType *v) { Push("DLDataType", f->name, *v); }
+    void operator()(MLCTypeField *f, DLDevice *v) { Push("DLDevice", f->name, *v); }
+    void operator()(MLCTypeField *f, Optional<void *> *v) { Push("Optional<void *>", f->name, *v); }
+    void operator()(MLCTypeField *f, void **v) { Push("void *", f->name, *v); }
+    void operator()(MLCTypeField *f, const char **v) { Push("const char *", f->name, *v); }
+
+    void Push(const char *ty, const char *name, Any value) {
+      types->push_back(ty);
+      names->push_back(name);
+      values->push_back(value);
+    }
+    List<Str> *types;
+    List<Str> *names;
+    UList *values;
+  };
+  List<Str> types;
+  List<Str> names;
+  UList values;
+  MLCTypeInfo *info = ::mlc::Lib::GetTypeInfo(root.GetTypeIndex());
+  ::mlc::core::VisitFields(root.get(), info, Visitor{&types, &names, &values});
+  return UList{types, names, values};
+});
+
+struct FieldFoundException : public ::std::exception {};
+
+struct FieldGetter {
+  void operator()(MLCTypeField *f, const Any *any) { Check(f->name, any); }
+  void operator()(MLCTypeField *f, ObjectRef *obj) { Check(f->name, obj); }
+  void operator()(MLCTypeField *f, Optional<ObjectRef> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<bool> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<int64_t> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<double> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<DLDevice> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<DLDataType> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, bool *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int8_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int16_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int32_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int64_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, float *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, double *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, DLDataType *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, DLDevice *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, Optional<void *> *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, void **v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, const char **v) { Check(f->name, v); }
+
+  template <typename T> void Check(const char *name, T *v) {
+    if (std::strcmp(name, target_name) == 0) {
+      *ret = Any(*v);
+      throw FieldFoundException();
+    }
+  }
+  const char *target_name;
+  Any *ret;
+};
+
+struct FieldSetter {
+  void operator()(MLCTypeField *f, Any *any) { Check(f->name, any); }
+  void operator()(MLCTypeField *f, ObjectRef *obj) { Check(f->name, obj); }
+  void operator()(MLCTypeField *f, Optional<ObjectRef> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<bool> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<int64_t> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<double> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<DLDevice> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, Optional<DLDataType> *opt) { Check(f->name, opt); }
+  void operator()(MLCTypeField *f, bool *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int8_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int16_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int32_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, int64_t *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, float *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, double *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, DLDataType *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, DLDevice *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, Optional<void *> *v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, void **v) { Check(f->name, v); }
+  void operator()(MLCTypeField *f, const char **v) { Check(f->name, v); }
+
+  template <typename T> void Check(const char *name, T *v) {
+    if (std::strcmp(name, target_name) == 0) {
+      if constexpr (std::is_same_v<T, Any>) {
+        *v = src;
+      } else {
+        *v = src.operator T();
+      }
+      throw FieldFoundException();
+    }
+  }
+  const char *target_name;
+  Any src;
+};
+
+MLC_REGISTER_FUNC("mlc.testing.FieldGet").set_body([](ObjectRef root, const char *target_name) {
+  Any ret;
+  MLCTypeInfo *info = ::mlc::Lib::GetTypeInfo(root.GetTypeIndex());
+  try {
+    ::mlc::core::VisitFields(root.get(), info, FieldGetter{target_name, &ret});
+  } catch (FieldFoundException &) {
+    return ret;
+  }
+  MLC_THROW(ValueError) << "Field not found: " << target_name;
+  MLC_UNREACHABLE();
+});
+
+MLC_REGISTER_FUNC("mlc.testing.FieldSet").set_body([](ObjectRef root, const char *target_name, Any src) {
+  MLCTypeInfo *info = ::mlc::Lib::GetTypeInfo(root.GetTypeIndex());
+  try {
+    ::mlc::core::VisitFields(root.get(), info, FieldSetter{target_name, src});
+  } catch (FieldFoundException &) {
+    return;
+  }
+  MLC_THROW(ValueError) << "Field not found: " << target_name;
   MLC_UNREACHABLE();
 });
 

--- a/cpp/printer.cc
+++ b/cpp/printer.cc
@@ -676,6 +676,8 @@ inline void PythonDocPrinter::PrintTypedDoc(const Literal &doc) {
   int32_t type_index = value.GetTypeIndex();
   if (!value.defined()) {
     output_ << "None";
+  } else if (type_index == kMLCBool) {
+    output_ << (value.operator bool() ? "True" : "False");
   } else if (type_index == kMLCInt) {
     output_ << value.operator int64_t();
   } else if (type_index == kMLCFloat) {
@@ -1022,12 +1024,18 @@ inline void PythonDocPrinter::PrintTypedDoc(const DocString &doc) {
   }
 }
 
-mlc::Str DocToPythonScript(Node node, PrinterConfig cfg) {
+} // namespace
+} // namespace printer
+} // namespace mlc
+
+namespace mlc {
+
+mlc::Str DocToPythonScript(mlc::printer::Node node, mlc::printer::PrinterConfig cfg) {
   if (cfg->num_context_lines < 0) {
     constexpr int32_t kMaxInt32 = 2147483647;
     cfg->num_context_lines = kMaxInt32;
   }
-  PythonDocPrinter printer(cfg);
+  printer::PythonDocPrinter printer(cfg);
   printer.Append(node, cfg);
   mlc::Str result = printer.GetString();
   while (!result->empty() && std::isspace(result->back())) {
@@ -1036,9 +1044,8 @@ mlc::Str DocToPythonScript(Node node, PrinterConfig cfg) {
   return result;
 }
 
-MLC_REGISTER_FUNC("mlc.printer.DocToPythonScript").set_body(DocToPythonScript);
-MLC_REGISTER_FUNC("mlc.printer.ToPython").set_body(::mlc::printer::ToPython);
+Str ToPython(const ObjectRef &obj, const mlc::printer::PrinterConfig &cfg) {
+  return ::mlc::printer::ToPython(obj, cfg);
+}
 
-} // namespace
-} // namespace printer
 } // namespace mlc

--- a/include/mlc/base/alloc.h
+++ b/include/mlc/base/alloc.h
@@ -65,12 +65,14 @@ template <typename T> struct PODAllocator;
       ret->_mlc_header.type_index = static_cast<int32_t>(TypeIndex);                                                   \
       ret->_mlc_header.ref_cnt = 0;                                                                                    \
       ret->_mlc_header.v.deleter = PODAllocator::Deleter;                                                              \
+      ret->data.v_int64 = 0;                                                                                           \
       ret->data.Field = data;                                                                                          \
       return reinterpret_cast<MLCAny *>(ret);                                                                          \
     }                                                                                                                  \
     static void Deleter(void *objptr) { delete static_cast<MLCBoxedPOD *>(objptr); }                                   \
   }
 
+MLC_DEF_POD_ALLOCATOR(bool, MLCTypeIndex::kMLCBool, v_bool);
 MLC_DEF_POD_ALLOCATOR(int64_t, MLCTypeIndex::kMLCInt, v_int64);
 MLC_DEF_POD_ALLOCATOR(double, MLCTypeIndex::kMLCFloat, v_float64);
 MLC_DEF_POD_ALLOCATOR(DLDataType, MLCTypeIndex::kMLCDataType, v_dtype);

--- a/include/mlc/base/base_traits.h
+++ b/include/mlc/base/base_traits.h
@@ -74,6 +74,7 @@ template <typename T> inline constexpr bool IsTemplate = IsTemplateImpl<T>::valu
 
 // IsPOD<T>
 template <typename T, typename = void> struct IsPODImpl : std::false_type {};
+template <> struct IsPODImpl<bool> : std::true_type {};
 template <typename Int> struct IsPODImpl<Int, std::enable_if_t<std::is_integral_v<Int>>> : std::true_type {};
 template <typename Float>
 struct IsPODImpl<Float, std::enable_if_t<std::is_floating_point_v<Float>>> : std::true_type {};

--- a/include/mlc/base/optional.h
+++ b/include/mlc/base/optional.h
@@ -181,6 +181,7 @@ public:
     return *this;                                                                                                      \
   }
 
+MLC_DEFINE_POD_OPT(bool, v_bool)
 MLC_DEFINE_POD_OPT(int64_t, v_int64)
 MLC_DEFINE_POD_OPT(double, v_float64)
 MLC_DEFINE_POD_OPT(DLDevice, v_device)

--- a/include/mlc/base/ref.h
+++ b/include/mlc/base/ref.h
@@ -252,6 +252,7 @@ public:
     Str str() const;                                                                                                   \
   }
 
+MLC_DEFINE_POD_REF(bool, v_bool);
 MLC_DEFINE_POD_REF(int64_t, v_int64);
 MLC_DEFINE_POD_REF(double, v_float64);
 MLC_DEFINE_POD_REF(DLDevice, v_device);

--- a/include/mlc/base/traits_scalar.h
+++ b/include/mlc/base/traits_scalar.h
@@ -7,6 +7,25 @@
 namespace mlc {
 namespace base {
 
+template <> struct TypeTraits<bool> {
+  static constexpr int32_t type_index = static_cast<int32_t>(MLCTypeIndex::kMLCBool);
+  static constexpr const char *type_str = "bool";
+
+  MLC_INLINE static void TypeToAny(bool src, MLCAny *ret) {
+    ret->type_index = static_cast<int32_t>(MLCTypeIndex::kMLCBool);
+    ret->v.v_int64 = static_cast<int64_t>(src);
+  }
+  MLC_INLINE static bool AnyToTypeOwned(const MLCAny *v) {
+    MLCTypeIndex ty = static_cast<MLCTypeIndex>(v->type_index);
+    if (ty == MLCTypeIndex::kMLCBool) {
+      return v->v.v_bool;
+    }
+    throw TemporaryTypeError();
+  }
+  MLC_INLINE static bool AnyToTypeUnowned(const MLCAny *v) { return AnyToTypeOwned(v); }
+  MLC_INLINE static std::string __str__(bool src) { return src ? "True" : "False"; }
+};
+
 template <typename Int> struct TypeTraits<Int, std::enable_if_t<std::is_integral_v<Int>>> {
   static constexpr int32_t type_index = static_cast<int32_t>(MLCTypeIndex::kMLCInt);
   static constexpr const char *type_str = "int";

--- a/include/mlc/c_api.h
+++ b/include/mlc/c_api.h
@@ -67,12 +67,13 @@ typedef enum {
   // - `Any::type_index` is never `kMLCRawStr`
   // - `AnyView::type_index` can be `kMLCRawStr`
   kMLCNone = 0,
-  kMLCInt = 1,
-  kMLCFloat = 2,
-  kMLCPtr = 3,
-  kMLCDataType = 4,
-  kMLCDevice = 5,
-  kMLCRawStr = 6,
+  kMLCBool = 1,
+  kMLCInt = 2,
+  kMLCFloat = 3,
+  kMLCPtr = 4,
+  kMLCDataType = 5,
+  kMLCDevice = 6,
+  kMLCRawStr = 7,
   kMLCStaticObjectBegin = 1000,
   // kMLCCore [1000: 1100) {
   kMLCCoreBegin = 1000,
@@ -118,6 +119,7 @@ typedef struct {
 } MLCByteArray;
 
 typedef union {
+  bool v_bool;            // booleans
   int64_t v_int64;        // integers
   double v_float64;       // floating-point numbers
   DLDataType v_dtype;     // data type

--- a/include/mlc/core/all.h
+++ b/include/mlc/core/all.h
@@ -83,11 +83,13 @@ MLC_INLINE void DeleteExternObject(Object *objptr) {
       MLC_INLINE void operator()(MLCTypeField *, Any *any) { any->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, ObjectRef *obj) { obj->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<ObjectRef> *opt) { opt->Reset(); }
+      MLC_INLINE void operator()(MLCTypeField *, Optional<bool> *opt) { opt->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<int64_t> *opt) { opt->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<double> *opt) { opt->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<DLDevice> *opt) { opt->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<DLDataType> *opt) { opt->Reset(); }
       MLC_INLINE void operator()(MLCTypeField *, Optional<void *> *opt) { opt->Reset(); }
+      MLC_INLINE void operator()(MLCTypeField *, bool *) {}
       MLC_INLINE void operator()(MLCTypeField *, int8_t *) {}
       MLC_INLINE void operator()(MLCTypeField *, int16_t *) {}
       MLC_INLINE void operator()(MLCTypeField *, int32_t *) {}

--- a/include/mlc/core/field_visitor.h
+++ b/include/mlc/core/field_visitor.h
@@ -26,6 +26,8 @@ template <typename Visitor> inline void VisitFields(Object *root, MLCTypeInfo *i
       int32_t type_index = reinterpret_cast<MLCTypingAtomic *>(field->ty)->type_index;
       if (type_index >= MLCTypeIndex::kMLCStaticObjectBegin && num_bytes == sizeof(MLCObjPtr)) {
         visitor(field, static_cast<ObjectRef *>(field_addr));
+      } else if (type_index == kMLCBool && num_bytes == 1) {
+        visitor(field, static_cast<bool *>(field_addr));
       } else if (type_index == kMLCInt && num_bytes == 1) {
         visitor(field, static_cast<int8_t *>(field_addr));
       } else if (type_index == kMLCInt && num_bytes == 2) {
@@ -57,6 +59,8 @@ template <typename Visitor> inline void VisitFields(Object *root, MLCTypeInfo *i
       if (ty->type_index == kMLCTypingAtomic) {
         if (ty_atomic->type_index >= kMLCStaticObjectBegin) {
           visitor(field, static_cast<Optional<ObjectRef> *>(field_addr));
+        } else if (ty_atomic->type_index == kMLCBool) {
+          visitor(field, static_cast<Optional<bool> *>(field_addr));
         } else if (ty_atomic->type_index == kMLCInt) {
           visitor(field, static_cast<Optional<int64_t> *>(field_addr));
         } else if (ty_atomic->type_index == kMLCFloat) {
@@ -104,6 +108,8 @@ template <typename Visitor> inline void VisitStructure(Object *root, MLCTypeInfo
       int32_t type_index = reinterpret_cast<MLCTypingAtomic *>(field->ty)->type_index;
       if (type_index >= MLCTypeIndex::kMLCStaticObjectBegin && num_bytes == sizeof(MLCObjPtr)) {
         visitor(field, field_kind, static_cast<ObjectRef *>(field_addr));
+      } else if (type_index == kMLCBool && num_bytes == 1) {
+        visitor(field, field_kind, static_cast<bool *>(field_addr));
       } else if (type_index == kMLCInt && num_bytes == 1) {
         visitor(field, field_kind, static_cast<int8_t *>(field_addr));
       } else if (type_index == kMLCInt && num_bytes == 2) {
@@ -135,6 +141,8 @@ template <typename Visitor> inline void VisitStructure(Object *root, MLCTypeInfo
       if (ty->type_index == kMLCTypingAtomic) {
         if (ty_atomic->type_index >= kMLCStaticObjectBegin) {
           visitor(field, field_kind, static_cast<Optional<ObjectRef> *>(field_addr));
+        } else if (ty_atomic->type_index == kMLCBool) {
+          visitor(field, field_kind, static_cast<Optional<bool> *>(field_addr));
         } else if (ty_atomic->type_index == kMLCInt) {
           visitor(field, field_kind, static_cast<Optional<int64_t> *>(field_addr));
         } else if (ty_atomic->type_index == kMLCFloat) {
@@ -212,10 +220,12 @@ inline void TopoVisit(Object *root, std::function<void(Object *object, MLCTypeIn
         state->TrackObject(current, v);
       }
     }
+    MLC_INLINE void operator()(MLCTypeField *, Optional<bool> *) {}
     MLC_INLINE void operator()(MLCTypeField *, Optional<int64_t> *) {}
     MLC_INLINE void operator()(MLCTypeField *, Optional<double> *) {}
     MLC_INLINE void operator()(MLCTypeField *, Optional<DLDevice> *) {}
     MLC_INLINE void operator()(MLCTypeField *, Optional<DLDataType> *) {}
+    MLC_INLINE void operator()(MLCTypeField *, bool *) {}
     MLC_INLINE void operator()(MLCTypeField *, int8_t *) {}
     MLC_INLINE void operator()(MLCTypeField *, int16_t *) {}
     MLC_INLINE void operator()(MLCTypeField *, int32_t *) {}

--- a/include/mlc/core/object_path.h
+++ b/include/mlc/core/object_path.h
@@ -129,6 +129,8 @@ inline bool ObjectPathObj::Equal(const ObjectPathObj *other) const {
       MLC_OBJ_PATH_CHECK_SEG(p->key, q->key, Object *);
     } else if (type_index == kMLCNone) {
       return true;
+    } else if (type_index == kMLCBool) {
+      MLC_OBJ_PATH_CHECK_SEG(p->key, q->key, bool);
     } else if (type_index == kMLCInt) {
       MLC_OBJ_PATH_CHECK_SEG(p->key, q->key, int64_t);
     } else if (type_index == kMLCFloat) {

--- a/include/mlc/core/typing.h
+++ b/include/mlc/core/typing.h
@@ -42,6 +42,8 @@ struct AtomicTypeObj : protected MLCTypingAtomic {
   ::mlc::Str __str__() const {
     if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCNone)) {
       return "None";
+    } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCBool)) {
+      return "bool";
     } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCInt)) {
       return "int";
     } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCFloat)) {
@@ -70,6 +72,8 @@ struct AtomicTypeObj : protected MLCTypingAtomic {
   ::mlc::Str __cxx_str__() const {
     if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCNone)) {
       return "std::nullptr_t";
+    } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCBool)) {
+      return "bool";
     } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCInt)) {
       return "int64_t";
     } else if (type_index == static_cast<int32_t>(MLCTypeIndex::kMLCFloat)) {

--- a/include/mlc/printer/ast.h
+++ b/include/mlc/printer/ast.h
@@ -152,6 +152,7 @@ struct LiteralObj : public ::mlc::Object {
 }; // struct LiteralObj
 
 struct Literal : public ::mlc::printer::Expr {
+  static Literal Bool(bool value) { return Literal(mlc::List<ObjectPath>(), Any(value)); }
   static Literal Int(int64_t value) { return Literal(mlc::List<ObjectPath>(), Any(value)); }
   static Literal Str(mlc::Str value) { return Literal(mlc::List<ObjectPath>(), Any(value)); }
   static Literal Float(double value) { return Literal(mlc::List<ObjectPath>(), Any(value)); }

--- a/python/mlc/__init__.py
+++ b/python/mlc/__init__.py
@@ -1,4 +1,4 @@
 from . import _cython, cc, dataclasses, parser, printer
 from ._cython import Ptr, Str
-from .core import DataType, Device, Dict, Error, Func, List, Object, ObjectPath, typing
+from .core import DataType, Device, Dict, Error, Func, List, Object, ObjectPath, json_loads, typing
 from .dataclasses import PyClass, c_class, py_class

--- a/python/mlc/core/__init__.py
+++ b/python/mlc/core/__init__.py
@@ -3,7 +3,7 @@ from .device import Device
 from .dict import Dict
 from .dtype import DataType
 from .error import Error
-from .func import Func
+from .func import Func, json_loads
 from .list import List
 from .object import Object
 from .object_path import ObjectPath

--- a/python/mlc/core/func.py
+++ b/python/mlc/core/func.py
@@ -34,3 +34,10 @@ class Func(Object):
             return func
 
         return decorator
+
+
+def json_loads(s: str) -> Any:
+    return _json_loads(s)
+
+
+_json_loads = Func.get("mlc.core.JSONLoads")

--- a/python/mlc/core/typing.py
+++ b/python/mlc/core/typing.py
@@ -148,15 +148,17 @@ def from_py(ann: type) -> Type:
     raise ValueError(f"Unsupported type: {ann}")
 
 
-_kMLCInt = 1
-_kMLCFloat = 2
-_kMLCPtr = 3
-_kMLCDataType = 4
-_kMLCDevice = 5
-_kMLCRawStr = 6
+_kMLCBool = 1
+_kMLCInt = 2
+_kMLCFloat = 3
+_kMLCPtr = 4
+_kMLCDataType = 5
+_kMLCDevice = 6
+_kMLCRawStr = 7
 _kMLCStaticObjectBegin = 1000
 _kMLCStr = 1005
 _Any = AnyType()
+_BOOL = AtomicType(_kMLCBool)
 _INT = AtomicType(_kMLCInt)
 _FLOAT = AtomicType(_kMLCFloat)
 _PTR = AtomicType(_kMLCPtr)
@@ -164,6 +166,7 @@ _STR = AtomicType(_kMLCStr)
 _UList = List(_Any)
 _UDict = Dict(_Any, _Any)
 _TYPE_INDEX_TO_CTYPES = {
+    _kMLCBool: ctypes.c_bool,
     _kMLCInt: ctypes.c_int64,
     _kMLCFloat: ctypes.c_double,
     _kMLCPtr: Ptr,
@@ -172,6 +175,7 @@ _TYPE_INDEX_TO_CTYPES = {
     _kMLCRawStr: Ptr,
 }
 _PY_TYPE_TO_MLC_TYPE: dict[typing.Any, Type] = {
+    bool: _BOOL,
     int: _INT,
     float: _FLOAT,
     Ptr: _PTR,

--- a/python/mlc/printer/ast.py
+++ b/python/mlc/printer/ast.py
@@ -153,23 +153,7 @@ class StmtBlock(Stmt):
 
 @mlcd.c_class("mlc.printer.ast.Literal")
 class Literal(Expr):
-    value: Any  # int, str, float, None
-
-    @staticmethod
-    def Int(value: int) -> "Literal":
-        return Literal(value=value)
-
-    @staticmethod
-    def Str(value: str) -> "Literal":
-        return Literal(value=value)
-
-    @staticmethod
-    def Float(value: float) -> "Literal":
-        return Literal(value=value)
-
-    @staticmethod
-    def Null() -> "Literal":
-        return Literal(value=None)
+    value: Any  # int, str, float, bool, None
 
 
 @mlcd.c_class("mlc.printer.ast.Id")

--- a/python/mlc/testing/dataclasses.py
+++ b/python/mlc/testing/dataclasses.py
@@ -1,0 +1,117 @@
+from typing import Any, Optional
+
+import mlc
+
+
+@mlc.c_class("mlc.testing.c_class")
+class CClassForTest(mlc.Object):
+    bool_: bool
+    i8: int
+    i16: int
+    i32: int
+    i64: int
+    f32: float
+    f64: float
+    raw_ptr: mlc.Ptr
+    dtype: mlc.DataType
+    device: mlc.Device
+    any: Any
+    func: mlc.Func
+    ulist: list[Any]
+    udict: dict
+    str_: str
+    str_readonly: str
+    ###
+    list_any: list[Any]
+    list_list_int: list[list[int]]
+    dict_any_any: dict[Any, Any]
+    dict_str_any: dict[str, Any]
+    dict_any_str: dict[Any, str]
+    dict_str_list_int: dict[str, list[int]]
+    ###
+    opt_bool: Optional[bool]
+    opt_i64: Optional[int]
+    opt_f64: Optional[float]
+    opt_raw_ptr: Optional[mlc.Ptr]
+    opt_dtype: Optional[mlc.DataType]
+    opt_device: Optional[mlc.Device]
+    opt_func: Optional[mlc.Func]
+    opt_ulist: Optional[list]
+    opt_udict: Optional[dict[Any, Any]]
+    opt_str: Optional[str]
+    ###
+    opt_list_any: Optional[list[Any]]
+    opt_list_list_int: Optional[list[list[int]]]
+    opt_dict_any_any: Optional[dict]
+    opt_dict_str_any: Optional[dict[str, Any]]
+    opt_dict_any_str: Optional[dict[Any, str]]
+    opt_dict_str_list_int: Optional[dict[str, list[int]]]
+
+    def i64_plus_one(self) -> int:
+        return type(self)._C(b"i64_plus_one", self)
+
+
+@mlc.py_class("mlc.testing.py_class")
+class PyClassForTest(mlc.PyClass):
+    bool_: bool
+    i8: int  # `py_class` doesn't support `int8`, it will effectively be `int64_t`
+    i16: int  # `py_class` doesn't support `int16`, it will effectively be `int64_t`
+    i32: int  # `py_class` doesn't support `int32`, it will effectively be `int64_t`
+    i64: int
+    f32: float  # `py_class` doesn't support `float32`, it will effectively be `float64`
+    f64: float
+    raw_ptr: mlc.Ptr
+    dtype: mlc.DataType
+    device: mlc.Device
+    any: Any
+    func: mlc.Func
+    ulist: list[Any]
+    udict: dict
+    str_: str
+    str_readonly: str
+    ###
+    list_any: list[Any]
+    list_list_int: list[list[int]]
+    dict_any_any: dict[Any, Any]
+    dict_str_any: dict[str, Any]
+    dict_any_str: dict[Any, str]
+    dict_str_list_int: dict[str, list[int]]
+    ###
+    opt_bool: Optional[bool]
+    opt_i64: Optional[int]
+    opt_f64: Optional[float]
+    opt_raw_ptr: Optional[mlc.Ptr]
+    opt_dtype: Optional[mlc.DataType]
+    opt_device: Optional[mlc.Device]
+    opt_func: Optional[mlc.Func]
+    opt_ulist: Optional[list]
+    opt_udict: Optional[dict[Any, Any]]
+    opt_str: Optional[str]
+    ###
+    opt_list_any: Optional[list[Any]]
+    opt_list_list_int: Optional[list[list[int]]]
+    opt_dict_any_any: Optional[dict]
+    opt_dict_str_any: Optional[dict[str, Any]]
+    opt_dict_any_str: Optional[dict[Any, str]]
+    opt_dict_str_list_int: Optional[dict[str, list[int]]]
+
+    def i64_plus_one(self) -> int:
+        return self.i64 + 1
+
+
+def visit_fields(obj: mlc.Object) -> list[tuple[str, str, Any]]:
+    types, names, values = _C_VisitFields(obj)
+    return list(zip(types, names, values))
+
+
+def field_get(obj: mlc.Object, name: str) -> Any:
+    return _C_FieldGet(obj, name)
+
+
+def field_set(obj: mlc.Object, name: str, value: Any) -> None:
+    _C_FieldSet(obj, name, value)
+
+
+_C_VisitFields = mlc.Func.get("mlc.testing.VisitFields")
+_C_FieldGet = mlc.Func.get("mlc.testing.FieldGet")
+_C_FieldSet = mlc.Func.get("mlc.testing.FieldSet")

--- a/tests/cpp/test_base_any.cc
+++ b/tests/cpp/test_base_any.cc
@@ -186,6 +186,46 @@ TEST(Any, Constructor_Float) {
   }
 }
 
+template <typename AnyType> struct Checker_Constructor_Bool {
+  static void Check(const AnyType &v, bool expected) {
+    CheckAnyPOD<bool>(v, MLCTypeIndex::kMLCBool, expected);
+    EXPECT_STREQ(v.str()->c_str(), expected ? "True" : "False");
+    EXPECT_EQ(v.operator bool(), expected);
+    // The following conversions should fail
+    CheckConvertFail([&]() { return v.operator int(); }, v.type_index, "int");
+    CheckConvertFail([&]() { return v.operator double(); }, v.type_index, "float");
+    CheckConvertFail([&]() { return v.operator DLDevice(); }, v.type_index, "Device");
+    CheckConvertFail([&]() { return v.operator DLDataType(); }, v.type_index, "dtype");
+    CheckConvertFail([&]() { return v.operator const char *(); }, v.type_index, "char *");
+    CheckConvertFail([&]() { return v.operator std::string(); }, v.type_index, "char *");
+    CheckConvertFail([&]() { return v.operator Ref<Object>(); }, v.type_index, "object.Object *");
+    CheckConvertFail([&]() { return v.operator ObjectRef(); }, v.type_index, "object.Object *");
+  }
+};
+
+// Then write the test that uses it:
+TEST(Any, Constructor_Bool) {
+  // Check for true
+  {
+    AnyView v_true(true);
+    Checker_Constructor_Bool<AnyView>::Check(v_true, true);
+  }
+  {
+    Any v_true(true);
+    Checker_Constructor_Bool<Any>::Check(v_true, true);
+  }
+
+  // Check for false
+  {
+    AnyView v_false(false);
+    Checker_Constructor_Bool<AnyView>::Check(v_false, false);
+  }
+  {
+    Any v_false(false);
+    Checker_Constructor_Bool<Any>::Check(v_false, false);
+  }
+}
+
 template <typename AnyType> struct Checker_Constructor_Ptr_NotNull {
   static void Check(const AnyType &v) {
     CheckAnyPOD<void *>(v, MLCTypeIndex::kMLCPtr, reinterpret_cast<void *>(0x1234));

--- a/tests/cpp/test_base_optional.cc
+++ b/tests/cpp/test_base_optional.cc
@@ -351,4 +351,152 @@ TEST(OptionalExceptions, ObjectRefType) {
   EXPECT_THROW(*opt_obj, Exception);
 }
 
+TEST(OptionalDefaultConstructor, BoolType) {
+  // Default constructor should yield an undefined Optional
+  Optional<bool> opt_bool;
+  EXPECT_FALSE(opt_bool.defined());
+  EXPECT_EQ(opt_bool.get(), nullptr);
+}
+
+TEST(OptionalNullConstructor, BoolType) {
+  // Constructing from Null should yield an undefined Optional
+  Optional<bool> opt_bool(Null);
+  EXPECT_FALSE(opt_bool.defined());
+  EXPECT_EQ(opt_bool.get(), nullptr);
+}
+
+TEST(OptionalValueConstructor, BoolType) {
+  // Construct with true
+  Optional<bool> opt_bool_true(true);
+  EXPECT_TRUE(opt_bool_true.defined());
+  EXPECT_TRUE(*opt_bool_true);
+
+  // Construct with false
+  Optional<bool> opt_bool_false(false);
+  EXPECT_TRUE(opt_bool_false.defined());
+  EXPECT_FALSE(*opt_bool_false);
+}
+
+TEST(OptionalCopyConstructor, BoolType) {
+  // Copy constructor
+  Optional<bool> opt_bool1(true);
+  Optional<bool> opt_bool2(opt_bool1);
+  EXPECT_TRUE(opt_bool2.defined());
+  EXPECT_TRUE(*opt_bool2);
+}
+
+TEST(OptionalMoveConstructor, BoolType) {
+  // Move constructor
+  Optional<bool> opt_bool1(false);
+  Optional<bool> opt_bool2(std::move(opt_bool1));
+  EXPECT_TRUE(opt_bool2.defined());
+  EXPECT_FALSE(*opt_bool2);
+  EXPECT_FALSE(opt_bool1.defined());
+}
+
+TEST(OptionalAssignmentOperator, BoolType) {
+  // Copy assignment
+  Optional<bool> opt_bool1(true);
+  Optional<bool> opt_bool2;
+  opt_bool2 = opt_bool1;
+  EXPECT_TRUE(opt_bool2.defined());
+  EXPECT_TRUE(*opt_bool2);
+}
+
+TEST(OptionalMoveAssignmentOperator, BoolType) {
+  // Move assignment
+  Optional<bool> opt_bool1(false);
+  Optional<bool> opt_bool2;
+  opt_bool2 = std::move(opt_bool1);
+  EXPECT_TRUE(opt_bool2.defined());
+  EXPECT_FALSE(*opt_bool2);
+  EXPECT_FALSE(opt_bool1.defined());
+}
+
+TEST(OptionalAccessors, BoolType) {
+  // Accessing the underlying value
+  Optional<bool> opt_bool(true);
+  EXPECT_EQ(opt_bool.get(), &(*opt_bool));
+  EXPECT_TRUE(*opt_bool);
+}
+
+TEST(OptionalBoolConversion, BoolType) {
+  // Testing .defined() in an if statement
+  Optional<bool> opt_bool1;
+  EXPECT_FALSE(opt_bool1.defined());
+
+  Optional<bool> opt_bool2(false);
+  EXPECT_TRUE(opt_bool2.defined());
+  EXPECT_FALSE(*opt_bool2);
+}
+
+TEST(OptionalBoolConversionInIf, BoolType) {
+  Optional<bool> opt_bool1;
+  if (opt_bool1.defined()) {
+    FAIL() << "Expected false for undefined Optional<bool>";
+  }
+
+  Optional<bool> opt_bool2(true);
+  if (!opt_bool2.defined()) {
+    FAIL() << "Expected true for defined Optional<bool>";
+  }
+}
+
+TEST(OptionalReset, BoolType) {
+  // Resetting should make the Optional undefined again
+  Optional<bool> opt_bool(true);
+  EXPECT_TRUE(opt_bool.defined());
+  opt_bool.Reset();
+  EXPECT_FALSE(opt_bool.defined());
+}
+
+TEST(OptionalExceptions, BoolType) {
+  // Dereferencing an undefined Optional<bool> should throw
+  Optional<bool> opt_bool;
+  EXPECT_THROW(*opt_bool, Exception);
+}
+
+// Conversions with Any/AnyView (optional, if your code supports these for bool too)
+TEST(OptionalAnyConversion, BoolType) {
+  Optional<bool> opt_bool(true);
+  Any any = opt_bool;
+  EXPECT_TRUE(any.operator bool());
+}
+
+TEST(OptionalAnyViewConversion, BoolType) {
+  Optional<bool> opt_bool(true);
+  AnyView view = opt_bool;
+  EXPECT_TRUE(view.operator bool());
+}
+
+TEST(OptionalConstructFromAny, BoolType) {
+  Any any(true);
+  Optional<bool> opt_bool = any.operator Optional<bool>();
+  EXPECT_TRUE(opt_bool.defined());
+  EXPECT_TRUE(*opt_bool);
+}
+
+TEST(OptionalConstructFromAnyView, BoolType) {
+  AnyView view(true);
+  Optional<bool> opt_bool = view.operator Optional<bool>();
+  EXPECT_TRUE(opt_bool.defined());
+  EXPECT_TRUE(*opt_bool);
+}
+
+TEST(OptionalAssignFromAny, BoolType) {
+  Optional<bool> opt_bool;
+  Any any(false);
+  opt_bool = any.operator Optional<bool>();
+  EXPECT_TRUE(opt_bool.defined());
+  EXPECT_FALSE(*opt_bool);
+}
+
+TEST(OptionalAssignFromAnyView, BoolType) {
+  Optional<bool> opt_bool;
+  AnyView view(false);
+  opt_bool = view.operator Optional<bool>();
+  EXPECT_TRUE(opt_bool.defined());
+  EXPECT_FALSE(*opt_bool);
+}
+
 } // namespace

--- a/tests/cpp/test_base_ref.cc
+++ b/tests/cpp/test_base_ref.cc
@@ -578,6 +578,211 @@ TEST(RefPOD, FromAnyNone) {
   }
 }
 
+TEST(RefBool, DefaultConstructor) {
+  // Default-constructed Ref<bool> should be null
+  Ref<bool> ref;
+  EXPECT_EQ(ref.get(), nullptr);
+}
+
+TEST(RefBool, ConstructorFromValue) {
+  // Creating a Ref<bool> from a boolean literal
+  Ref<bool> ref_true = Ref<bool>::New(true);
+  EXPECT_NE(ref_true.get(), nullptr);
+  EXPECT_TRUE(*ref_true);
+  EXPECT_EQ(GetRefCount(ref_true), 1);
+
+  // Also test a false case
+  Ref<bool> ref_false = Ref<bool>::New(false);
+  EXPECT_NE(ref_false.get(), nullptr);
+  EXPECT_FALSE(*ref_false);
+  EXPECT_EQ(GetRefCount(ref_false), 1);
+}
+
+TEST(RefBool, CopyConstructor) {
+  // Copy construct from an existing Ref<bool>
+  Ref<bool> ref1 = Ref<bool>::New(true);
+  Ref<bool> ref2(ref1);
+  EXPECT_NE(ref1.get(), nullptr);
+  EXPECT_NE(ref2.get(), nullptr);
+  EXPECT_TRUE(*ref1);
+  EXPECT_TRUE(*ref2);
+  EXPECT_EQ(GetRefCount(ref1), 2);
+  EXPECT_EQ(GetRefCount(ref2), 2);
+}
+
+TEST(RefBool, MoveConstructor) {
+  // Move construct from an existing Ref<bool>
+  Ref<bool> ref1 = Ref<bool>::New(true);
+  Ref<bool> ref2(std::move(ref1));
+  EXPECT_EQ(ref1.get(), nullptr);
+  EXPECT_NE(ref2.get(), nullptr);
+  EXPECT_TRUE(*ref2);
+  EXPECT_EQ(GetRefCount(ref2), 1);
+}
+
+TEST(RefBool, CopyAssignment) {
+  // Copy-assign one Ref<bool> to another
+  Ref<bool> ref1 = Ref<bool>::New(false);
+  Ref<bool> ref2;
+  ref2 = ref1;
+  EXPECT_NE(ref1.get(), nullptr);
+  EXPECT_NE(ref2.get(), nullptr);
+  EXPECT_FALSE(*ref1);
+  EXPECT_FALSE(*ref2);
+  EXPECT_EQ(GetRefCount(ref1), 2);
+  EXPECT_EQ(GetRefCount(ref2), 2);
+}
+
+TEST(RefBool, MoveAssignment) {
+  // Move-assign one Ref<bool> to another
+  Ref<bool> ref1 = Ref<bool>::New(false);
+  Ref<bool> ref2;
+  ref2 = std::move(ref1);
+  EXPECT_EQ(ref1.get(), nullptr);
+  EXPECT_NE(ref2.get(), nullptr);
+  EXPECT_FALSE(*ref2);
+  EXPECT_EQ(GetRefCount(ref2), 1);
+}
+
+TEST(RefBool, Dereference) {
+  Ref<bool> ref_true = Ref<bool>::New(true);
+  EXPECT_TRUE(*ref_true);
+  *ref_true = false;
+  EXPECT_FALSE(*ref_true);
+}
+
+TEST(RefBool, Null) {
+  // Construct from Null
+  Ref<bool> ref(Null);
+  EXPECT_EQ(ref.get(), nullptr);
+}
+
+TEST(RefBool, Reset) {
+  // Reset a Ref<bool> and ensure it becomes null
+  Ref<bool> ref = Ref<bool>::New(true);
+  EXPECT_NE(ref.get(), nullptr);
+  ref.Reset();
+  EXPECT_EQ(ref.get(), nullptr);
+}
+
+TEST(RefBool, ConversionToAny) {
+  // Convert Ref<bool> to Any
+  Ref<bool> ref = Ref<bool>::New(true);
+  Any any = ref;
+  ref.Reset();
+  EXPECT_TRUE(any.operator bool());
+  // Convert back from Any to Ref<bool>
+  ref = any.operator Ref<bool>();
+  EXPECT_TRUE(*ref);
+  EXPECT_EQ(GetRefCount(ref), 1);
+}
+
+TEST(RefBool, ConversionFromAny) {
+  // Convert a Ref<bool> inside an Any back to Ref<bool>
+  Any any = Ref<bool>::New(false);
+  Ref<bool> ref = any;
+  EXPECT_FALSE(*ref);
+  EXPECT_EQ(GetRefCount(ref), 1);
+}
+
+TEST(RefBool, ConversionToAnyView) {
+  // Convert Ref<bool> to AnyView
+  Ref<bool> ref = Ref<bool>::New(true);
+  AnyView any_view = ref;
+  ref.Reset();
+  EXPECT_TRUE(any_view.operator bool());
+  // Convert back from AnyView to Ref<bool>
+  ref = any_view.operator Ref<bool>();
+  EXPECT_TRUE(*ref);
+  EXPECT_EQ(GetRefCount(ref), 1);
+}
+
+TEST(RefBool, ConversionFromAnyView) {
+  // Convert a Ref<bool> inside an AnyView back to Ref<bool>
+  Any any = Ref<bool>::New(false);
+  AnyView any_view = any;
+  Ref<bool> ref = any_view;
+  EXPECT_FALSE(*ref);
+  EXPECT_EQ(GetRefCount(ref), 1);
+}
+
+TEST(RefBool, MultipleReferences) {
+  // Multiple references to the same Ref<bool>
+  Ref<bool> ref1 = Ref<bool>::New(true);
+  Ref<bool> ref2 = ref1;
+  Ref<bool> ref3 = ref1;
+  EXPECT_EQ(GetRefCount(ref1), 3);
+  EXPECT_EQ(GetRefCount(ref2), 3);
+  EXPECT_EQ(GetRefCount(ref3), 3);
+
+  ref2.Reset();
+  EXPECT_EQ(GetRefCount(ref1), 2);
+  ref3.Reset();
+  EXPECT_EQ(GetRefCount(ref1), 1);
+}
+
+TEST(RefBool, ComparisonOperators) {
+  // Test == and != for Ref<bool>
+  Ref<bool> ref_true1 = Ref<bool>::New(true);
+  Ref<bool> ref_true2 = Ref<bool>::New(true);
+  Ref<bool> ref_false = Ref<bool>::New(false);
+
+  // They point to different allocations, so operator== checks pointer identity
+  EXPECT_TRUE(ref_true1 == ref_true1);
+  EXPECT_FALSE(ref_true1 == ref_true2);
+  EXPECT_FALSE(ref_true1 == ref_false);
+  EXPECT_FALSE(ref_true2 == ref_false);
+
+  EXPECT_FALSE(ref_true1 != ref_true1);
+  EXPECT_TRUE(ref_true1 != ref_true2);
+  EXPECT_TRUE(ref_true1 != ref_false);
+  EXPECT_TRUE(ref_true2 != ref_false);
+}
+
+TEST(RefBool, NullComparison) {
+  // Comparing Ref<bool> to nullptr
+  Ref<bool> ref_null;
+  Ref<bool> ref_true = Ref<bool>::New(true);
+
+  EXPECT_TRUE(ref_null == nullptr);
+  EXPECT_FALSE(ref_true == nullptr);
+
+  EXPECT_FALSE(ref_null != nullptr);
+  EXPECT_TRUE(ref_true != nullptr);
+}
+
+TEST(RefBool, Defined) {
+  // defined() should return false if null, true otherwise
+  Ref<bool> ref_null;
+  Ref<bool> ref_true = Ref<bool>::New(true);
+
+  EXPECT_FALSE(ref_null.defined());
+  EXPECT_TRUE(ref_true.defined());
+}
+
+TEST(RefBool, DereferenceNull) {
+  // Attempting to dereference a null Ref<bool> should throw
+  Ref<bool> ref_null;
+  try {
+    *ref_null;
+    FAIL() << "Expected exception not thrown";
+  } catch (Exception &e) {
+    EXPECT_STREQ(e.what(), "Attempt to dereference a null pointer");
+  }
+}
+
+TEST(RefBool, ResetAndAccess) {
+  // Reset and then attempt to dereference
+  Ref<bool> ref = Ref<bool>::New(true);
+  ref.Reset();
+  try {
+    *ref;
+    FAIL() << "Expected exception not thrown";
+  } catch (Exception &e) {
+    EXPECT_STREQ(e.what(), "Attempt to dereference a null pointer");
+  }
+}
+
 static_assert(!std::is_assignable<Ref<int64_t> &, Ref<double>>::value,
               "Ref<int64_t> should not be assignable from Ref<double>");
 static_assert(!std::is_constructible<Ref<int64_t>, Ref<double>>::value,

--- a/tests/cpp/test_base_type_info.cc
+++ b/tests/cpp/test_base_type_info.cc
@@ -158,4 +158,54 @@ TEST(DynTypeInheritance, SubTestObj) {
   EXPECT_FALSE(obj->IsInstance<StrObj>());
 }
 
+template <typename Callable> void CheckSignature(Callable callable, const char *expected) {
+  EXPECT_STREQ(::mlc::base::FuncCanonicalize<Callable>::Sig().c_str(), expected);
+  Func func(std::move(callable));
+  EXPECT_NE(func.get(), nullptr);
+}
+
+TEST(FuncTraits, Signature) {
+  using CStr = const char *;
+  using CxxStr = std::string;
+  using VoidPtr = void *;
+  const char *cstr = "Hello";
+  CheckSignature([]() -> void {}, "() -> void");
+  CheckSignature([](Any, const Any, const Any &, Any &&) -> Any { return Any(); },
+                 "(0: Any, 1: Any, 2: Any, 3: Any) -> Any");
+  CheckSignature([](AnyView, const AnyView, const AnyView &, AnyView &&) -> AnyView { return AnyView(); },
+                 "(0: AnyView, 1: AnyView, 2: AnyView, 3: AnyView) -> AnyView");
+  CheckSignature([](int, const int, const int &, int &&) -> int { return 0; },
+                 "(0: int, 1: int, 2: int, 3: int) -> int");
+  CheckSignature([](double, const double, const double &, double &&) -> double { return 0.0; },
+                 "(0: float, 1: float, 2: float, 3: float) -> float");
+  CheckSignature([&](CStr, const CStr, const CStr &, CStr &&) -> CStr { return cstr; },
+                 "(0: char *, 1: char *, 2: char *, 3: char *) -> char *");
+  CheckSignature([](CxxStr, const CxxStr, const CxxStr &, CxxStr &&) -> CxxStr { return CxxStr(); },
+                 "(0: char *, 1: char *, 2: char *, 3: char *) -> char *");
+  CheckSignature([](VoidPtr, const VoidPtr, const VoidPtr &, VoidPtr &&) -> VoidPtr { return nullptr; },
+                 "(0: Ptr, 1: Ptr, 2: Ptr, 3: Ptr) -> Ptr");
+  CheckSignature([](DLDataType, const DLDataType, const DLDataType &, DLDataType &&) -> DLDataType { return {}; },
+                 "(0: dtype, 1: dtype, 2: dtype, 3: dtype) -> dtype");
+  CheckSignature([](DLDevice, const DLDevice, const DLDevice &, DLDevice &&) -> DLDevice { return {}; },
+                 "(0: Device, 1: Device, 2: Device, 3: Device) -> Device");
+  CheckSignature([](StrObj *, const StrObj *) -> Str { return Str{Null}; },
+                 "(0: object.StrObj *, 1: object.StrObj *) -> str");
+  CheckSignature([](Ref<StrObj>, const Ref<StrObj>, const Ref<StrObj> &,
+                    Ref<StrObj> &&) -> Ref<StrObj> { return Ref<StrObj>::New("Test"); },
+                 "(0: Ref<object.StrObj>, 1: Ref<object.StrObj>, 2: Ref<object.StrObj>, 3: Ref<object.StrObj>) -> "
+                 "Ref<object.StrObj>");
+  CheckSignature([](Str, const Str, const Str &, Str &&) -> Str { return Str{Null}; },
+                 "(0: str, 1: str, 2: str, 3: str) -> str");
+  CheckSignature(
+      [](Optional<int64_t>, Optional<ObjectRef>, Optional<Str>, Optional<DLDevice>, Optional<DLDataType>) -> void {},
+      "(0: Optional<int>, 1: Optional<object.Object>, 2: Optional<object.StrObj>, 3: Optional<Device>, 4: "
+      "Optional<dtype>) -> void");
+  CheckSignature([](bool, Optional<bool>, Ref<bool>) -> bool { return false; },
+                 "(0: bool, 1: Optional<bool>, 2: Ref<bool>) -> bool");
+  CheckSignature([](bool, Optional<bool>, Ref<bool>) -> Ref<bool> { return false; },
+                 "(0: bool, 1: Optional<bool>, 2: Ref<bool>) -> Ref<bool>");
+  CheckSignature([](bool, Optional<bool>, Ref<bool>) -> Optional<bool> { return false; },
+                 "(0: bool, 1: Optional<bool>, 2: Ref<bool>) -> Optional<bool>");
+}
+
 } // namespace

--- a/tests/cpp/test_core_func.cc
+++ b/tests/cpp/test_core_func.cc
@@ -110,51 +110,6 @@ TEST(Func, FunctionReturningRef) {
   EXPECT_EQ(result.operator Ref<StrObj>()->c_str(), std::string("Test Ref"));
 }
 
-template <typename Callable> void CheckSignature(Callable callable, const char *expected) {
-  using Traits = ::mlc::base::FuncCanonicalize<Callable>;
-  EXPECT_STREQ(Traits::Sig().c_str(), expected);
-  Func func(std::move(callable));
-  EXPECT_NE(func.get(), nullptr);
-}
-
-TEST(Func, Signature) {
-  using CStr = const char *;
-  using CxxStr = std::string;
-  using VoidPtr = void *;
-  const char *cstr = "Hello";
-  CheckSignature([]() -> void {}, "() -> void");
-  CheckSignature([](Any, const Any, const Any &, Any &&) -> Any { return Any(); },
-                 "(0: Any, 1: Any, 2: Any, 3: Any) -> Any");
-  CheckSignature([](AnyView, const AnyView, const AnyView &, AnyView &&) -> AnyView { return AnyView(); },
-                 "(0: AnyView, 1: AnyView, 2: AnyView, 3: AnyView) -> AnyView");
-  CheckSignature([](int, const int, const int &, int &&) -> int { return 0; },
-                 "(0: int, 1: int, 2: int, 3: int) -> int");
-  CheckSignature([](double, const double, const double &, double &&) -> double { return 0.0; },
-                 "(0: float, 1: float, 2: float, 3: float) -> float");
-  CheckSignature([&](CStr, const CStr, const CStr &, CStr &&) -> CStr { return cstr; },
-                 "(0: char *, 1: char *, 2: char *, 3: char *) -> char *");
-  CheckSignature([](CxxStr, const CxxStr, const CxxStr &, CxxStr &&) -> CxxStr { return CxxStr(); },
-                 "(0: char *, 1: char *, 2: char *, 3: char *) -> char *");
-  CheckSignature([](VoidPtr, const VoidPtr, const VoidPtr &, VoidPtr &&) -> VoidPtr { return nullptr; },
-                 "(0: Ptr, 1: Ptr, 2: Ptr, 3: Ptr) -> Ptr");
-  CheckSignature([](DLDataType, const DLDataType, const DLDataType &, DLDataType &&) -> DLDataType { return {}; },
-                 "(0: dtype, 1: dtype, 2: dtype, 3: dtype) -> dtype");
-  CheckSignature([](DLDevice, const DLDevice, const DLDevice &, DLDevice &&) -> DLDevice { return {}; },
-                 "(0: Device, 1: Device, 2: Device, 3: Device) -> Device");
-  CheckSignature([](StrObj *, const StrObj *) -> Str { return Str{Null}; },
-                 "(0: object.StrObj *, 1: object.StrObj *) -> str");
-  CheckSignature([](Ref<StrObj>, const Ref<StrObj>, const Ref<StrObj> &,
-                    Ref<StrObj> &&) -> Ref<StrObj> { return Ref<StrObj>::New("Test"); },
-                 "(0: Ref<object.StrObj>, 1: Ref<object.StrObj>, 2: Ref<object.StrObj>, 3: Ref<object.StrObj>) -> "
-                 "Ref<object.StrObj>");
-  CheckSignature([](Str, const Str, const Str &, Str &&) -> Str { return Str{Null}; },
-                 "(0: str, 1: str, 2: str, 3: str) -> str");
-  CheckSignature(
-      [](Optional<int64_t>, Optional<ObjectRef>, Optional<Str>, Optional<DLDevice>, Optional<DLDataType>) -> void {},
-      "(0: Optional<int>, 1: Optional<object.Object>, 2: Optional<object.StrObj>, 3: Optional<Device>, 4: "
-      "Optional<dtype>) -> void");
-}
-
 TEST(Func, ArgumentObjRawPtr) {
   Func f1([](Object *obj) { EXPECT_EQ(reinterpret_cast<MLCAny *>(obj)->ref_cnt, 1); });
   Func f2([](ObjectRef obj) { EXPECT_EQ(reinterpret_cast<MLCAny *>(obj.get())->ref_cnt, 2); });

--- a/tests/python/test_core_func.py
+++ b/tests/python/test_core_func.py
@@ -20,6 +20,13 @@ def test_cxx_int(x: int) -> None:
     assert isinstance(y, int) and y == x
 
 
+@pytest.mark.parametrize("x", [True, False])
+def test_cxx_bool(x: int) -> None:
+    func = mlc.Func.get("mlc.testing.cxx_bool")
+    y = func(x)
+    assert isinstance(y, bool) and y == x
+
+
 @pytest.mark.parametrize("x", [-1, 0, 1, 2.0, -2.0])
 def test_cxx_float(x: float) -> None:
     func = mlc.Func.get("mlc.testing.cxx_float")

--- a/tests/python/test_core_json.py
+++ b/tests/python/test_core_json.py
@@ -1,0 +1,18 @@
+import json
+
+import mlc
+
+
+def test_json_loads_bool() -> None:
+    src = json.dumps([True, False])
+    result = mlc.json_loads(src)
+    assert isinstance(result, mlc.List) and len(result) == 2
+    assert result[0] == True
+    assert result[1] == False
+
+
+def test_json_loads_none() -> None:
+    src = json.dumps([None])
+    result = mlc.json_loads(src)
+    assert isinstance(result, mlc.List) and len(result) == 1
+    assert result[0] is None

--- a/tests/python/test_dataclasses_copy.py
+++ b/tests/python/test_dataclasses_copy.py
@@ -7,6 +7,7 @@ import pytest
 
 @mlc.py_class
 class PyClassForTest(mlc.PyClass):
+    bool_: bool
     i64: int
     f64: float
     raw_ptr: mlc.Ptr
@@ -25,6 +26,7 @@ class PyClassForTest(mlc.PyClass):
     dict_any_str: dict[Any, str]
     dict_str_list_int: dict[str, list[int]]
     ###
+    opt_bool: Optional[bool]
     opt_i64: Optional[int]
     opt_f64: Optional[float]
     opt_raw_ptr: Optional[mlc.Ptr]
@@ -49,6 +51,7 @@ class PyClassForTest(mlc.PyClass):
 @pytest.fixture
 def mlc_class_for_test() -> PyClassForTest:
     return PyClassForTest(
+        bool_=True,
         i64=64,
         f64=2.5,
         raw_ptr=mlc.Ptr(0xDEADBEEF),
@@ -67,6 +70,7 @@ def mlc_class_for_test() -> PyClassForTest:
         dict_any_str={1: "1.0", 2.0: "2", "three": "four", 4: "5"},
         dict_str_list_int={"1": [1, 2, 3], "2": [4, 5, 6]},
         ###
+        opt_bool=None,
         opt_i64=-64,
         opt_f64=-2.5,
         opt_raw_ptr=mlc.Ptr(0xBEEFDEAD),
@@ -90,6 +94,7 @@ def test_copy_shallow(mlc_class_for_test: PyClassForTest) -> None:
     src = mlc_class_for_test
     dst = copy.copy(src)
     assert src != dst
+    assert src.bool_ == dst.bool_
     assert src.i64 == dst.i64
     assert src.f64 == dst.f64
     assert src.raw_ptr.value == dst.raw_ptr.value
@@ -106,6 +111,7 @@ def test_copy_shallow(mlc_class_for_test: PyClassForTest) -> None:
     assert src.dict_str_any == dst.dict_str_any
     assert src.dict_any_str == dst.dict_any_str
     assert src.dict_str_list_int == dst.dict_str_list_int
+    assert src.opt_bool == dst.opt_bool
     assert src.opt_i64 == dst.opt_i64
     assert src.opt_f64 == dst.opt_f64
     assert src.opt_raw_ptr.value == dst.opt_raw_ptr.value  # type: ignore[union-attr]

--- a/tests/python/test_dataclasses_prototype.py
+++ b/tests/python/test_dataclasses_prototype.py
@@ -1,56 +1,17 @@
-from typing import Any, Optional
-
-import mlc
 import mlc.dataclasses as mlcd
-
-
-@mlcd.py_class
-class PyClassForTest(mlcd.PyClass):
-    i64: int
-    f64: float
-    raw_ptr: mlc.Ptr
-    dtype: mlc.DataType
-    device: mlc.Device
-    any: Any
-    func: mlc.Func
-    ulist: list[Any]
-    udict: dict
-    str_: str
-    str_readonly: str
-    ###
-    list_any: list[Any]
-    list_list_int: list[list[int]]
-    dict_any_any: dict[Any, Any]
-    dict_str_any: dict[str, Any]
-    dict_any_str: dict[Any, str]
-    dict_str_list_int: dict[str, list[int]]
-    ###
-    opt_i64: Optional[int]
-    opt_f64: Optional[float]
-    opt_raw_ptr: Optional[mlc.Ptr]
-    opt_dtype: Optional[mlc.DataType]
-    opt_device: Optional[mlc.Device]
-    opt_func: Optional[mlc.Func]
-    opt_ulist: Optional[list]
-    opt_udict: Optional[dict[Any, Any]]
-    opt_str: Optional[str]
-    ###
-    opt_list_any: Optional[list[Any]]
-    opt_list_list_int: Optional[list[list[int]]]
-    opt_dict_any_any: Optional[dict]
-    opt_dict_str_any: Optional[dict[str, Any]]
-    opt_dict_any_str: Optional[dict[Any, str]]
-    opt_dict_str_list_int: Optional[dict[str, list[int]]]
-
-    def i64_plus_one(self) -> int:
-        return self.i64 + 1
+from mlc.testing.dataclasses import PyClassForTest
 
 
 def test_prototype_py() -> None:
     expected = """
-@mlc.dataclasses.c_class('test_dataclasses_prototype.PyClassForTest')
-class PyClassForTest:
+@mlc.dataclasses.c_class('mlc.testing.py_class')
+class py_class:
+  bool_: bool
+  i8: int
+  i16: int
+  i32: int
   i64: int
+  f32: float
   f64: float
   raw_ptr: mlc.Ptr
   dtype: mlc.DataType
@@ -67,6 +28,7 @@ class PyClassForTest:
   dict_str_any: dict[str, Any]
   dict_any_str: dict[Any, str]
   dict_str_list_int: dict[str, list[int]]
+  opt_bool: bool | None
   opt_i64: int | None
   opt_f64: float | None
   opt_raw_ptr: mlc.Ptr | None
@@ -89,9 +51,15 @@ class PyClassForTest:
 
 def test_prototype_cxx() -> None:
     expected = """
-namespace test_dataclasses_prototype {
-struct PyClassForTestObj : public ::mlc::Object {
+namespace mlc {
+namespace testing {
+struct py_classObj : public ::mlc::Object {
+  bool bool_;
+  int64_t i8;
+  int64_t i16;
+  int64_t i32;
   int64_t i64;
+  double f32;
   double f64;
   void* raw_ptr;
   DLDataType dtype;
@@ -108,6 +76,7 @@ struct PyClassForTestObj : public ::mlc::Object {
   ::mlc::Dict<::mlc::Str, ::mlc::Any> dict_str_any;
   ::mlc::Dict<::mlc::Any, ::mlc::Str> dict_any_str;
   ::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>> dict_str_list_int;
+  ::mlc::Optional<bool> opt_bool;
   ::mlc::Optional<int64_t> opt_i64;
   ::mlc::Optional<double> opt_f64;
   ::mlc::Optional<void*> opt_raw_ptr;
@@ -123,47 +92,54 @@ struct PyClassForTestObj : public ::mlc::Object {
   ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::Any>> opt_dict_str_any;
   ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Str>> opt_dict_any_str;
   ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>> opt_dict_str_list_int;
-  explicit PyClassForTestObj(int64_t i64, double f64, void* raw_ptr, DLDataType dtype, DLDevice device, ::mlc::Any any, ::mlc::Func func, ::mlc::List<::mlc::Any> ulist, ::mlc::Dict<::mlc::Any, ::mlc::Any> udict, ::mlc::Str str_, ::mlc::Str str_readonly, ::mlc::List<::mlc::Any> list_any, ::mlc::List<::mlc::List<int64_t>> list_list_int, ::mlc::Dict<::mlc::Any, ::mlc::Any> dict_any_any, ::mlc::Dict<::mlc::Str, ::mlc::Any> dict_str_any, ::mlc::Dict<::mlc::Any, ::mlc::Str> dict_any_str, ::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>> dict_str_list_int, ::mlc::Optional<int64_t> opt_i64, ::mlc::Optional<double> opt_f64, ::mlc::Optional<void*> opt_raw_ptr, ::mlc::Optional<DLDataType> opt_dtype, ::mlc::Optional<DLDevice> opt_device, ::mlc::Optional<::mlc::Func> opt_func, ::mlc::Optional<::mlc::List<::mlc::Any>> opt_ulist, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>> opt_udict, ::mlc::Optional<::mlc::Str> opt_str, ::mlc::Optional<::mlc::List<::mlc::Any>> opt_list_any, ::mlc::Optional<::mlc::List<::mlc::List<int64_t>>> opt_list_list_int, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>> opt_dict_any_any, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::Any>> opt_dict_str_any, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Str>> opt_dict_any_str, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>> opt_dict_str_list_int): i64(i64), f64(f64), raw_ptr(raw_ptr), dtype(dtype), device(device), any(any), func(func), ulist(ulist), udict(udict), str_(str_), str_readonly(str_readonly), list_any(list_any), list_list_int(list_list_int), dict_any_any(dict_any_any), dict_str_any(dict_str_any), dict_any_str(dict_any_str), dict_str_list_int(dict_str_list_int), opt_i64(opt_i64), opt_f64(opt_f64), opt_raw_ptr(opt_raw_ptr), opt_dtype(opt_dtype), opt_device(opt_device), opt_func(opt_func), opt_ulist(opt_ulist), opt_udict(opt_udict), opt_str(opt_str), opt_list_any(opt_list_any), opt_list_list_int(opt_list_list_int), opt_dict_any_any(opt_dict_any_any), opt_dict_str_any(opt_dict_str_any), opt_dict_any_str(opt_dict_any_str), opt_dict_str_list_int(opt_dict_str_list_int) {}
-  MLC_DEF_DYN_TYPE(_EXPORTS, PyClassForTestObj, ::mlc::Object, "test_dataclasses_prototype.PyClassForTest");
-};  // struct PyClassForTestObj
+  explicit py_classObj(bool bool_, int64_t i8, int64_t i16, int64_t i32, int64_t i64, double f32, double f64, void* raw_ptr, DLDataType dtype, DLDevice device, ::mlc::Any any, ::mlc::Func func, ::mlc::List<::mlc::Any> ulist, ::mlc::Dict<::mlc::Any, ::mlc::Any> udict, ::mlc::Str str_, ::mlc::Str str_readonly, ::mlc::List<::mlc::Any> list_any, ::mlc::List<::mlc::List<int64_t>> list_list_int, ::mlc::Dict<::mlc::Any, ::mlc::Any> dict_any_any, ::mlc::Dict<::mlc::Str, ::mlc::Any> dict_str_any, ::mlc::Dict<::mlc::Any, ::mlc::Str> dict_any_str, ::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>> dict_str_list_int, ::mlc::Optional<bool> opt_bool, ::mlc::Optional<int64_t> opt_i64, ::mlc::Optional<double> opt_f64, ::mlc::Optional<void*> opt_raw_ptr, ::mlc::Optional<DLDataType> opt_dtype, ::mlc::Optional<DLDevice> opt_device, ::mlc::Optional<::mlc::Func> opt_func, ::mlc::Optional<::mlc::List<::mlc::Any>> opt_ulist, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>> opt_udict, ::mlc::Optional<::mlc::Str> opt_str, ::mlc::Optional<::mlc::List<::mlc::Any>> opt_list_any, ::mlc::Optional<::mlc::List<::mlc::List<int64_t>>> opt_list_list_int, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>> opt_dict_any_any, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::Any>> opt_dict_str_any, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Str>> opt_dict_any_str, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>> opt_dict_str_list_int): bool_(bool_), i8(i8), i16(i16), i32(i32), i64(i64), f32(f32), f64(f64), raw_ptr(raw_ptr), dtype(dtype), device(device), any(any), func(func), ulist(ulist), udict(udict), str_(str_), str_readonly(str_readonly), list_any(list_any), list_list_int(list_list_int), dict_any_any(dict_any_any), dict_str_any(dict_str_any), dict_any_str(dict_any_str), dict_str_list_int(dict_str_list_int), opt_bool(opt_bool), opt_i64(opt_i64), opt_f64(opt_f64), opt_raw_ptr(opt_raw_ptr), opt_dtype(opt_dtype), opt_device(opt_device), opt_func(opt_func), opt_ulist(opt_ulist), opt_udict(opt_udict), opt_str(opt_str), opt_list_any(opt_list_any), opt_list_list_int(opt_list_list_int), opt_dict_any_any(opt_dict_any_any), opt_dict_str_any(opt_dict_str_any), opt_dict_any_str(opt_dict_any_str), opt_dict_str_list_int(opt_dict_str_list_int) {}
+  MLC_DEF_DYN_TYPE(_EXPORTS, py_classObj, ::mlc::Object, "mlc.testing.py_class");
+};  // struct py_classObj
 
-struct PyClassForTest : public ::mlc::ObjectRef {
-  MLC_DEF_OBJ_REF(_EXPORTS, PyClassForTest, PyClassForTestObj, ::mlc::ObjectRef)
-    .Field("i64", &PyClassForTestObj::i64)
-    .Field("f64", &PyClassForTestObj::f64)
-    .Field("raw_ptr", &PyClassForTestObj::raw_ptr)
-    .Field("dtype", &PyClassForTestObj::dtype)
-    .Field("device", &PyClassForTestObj::device)
-    .Field("any", &PyClassForTestObj::any)
-    .Field("func", &PyClassForTestObj::func)
-    .Field("ulist", &PyClassForTestObj::ulist)
-    .Field("udict", &PyClassForTestObj::udict)
-    .Field("str_", &PyClassForTestObj::str_)
-    .Field("str_readonly", &PyClassForTestObj::str_readonly)
-    .Field("list_any", &PyClassForTestObj::list_any)
-    .Field("list_list_int", &PyClassForTestObj::list_list_int)
-    .Field("dict_any_any", &PyClassForTestObj::dict_any_any)
-    .Field("dict_str_any", &PyClassForTestObj::dict_str_any)
-    .Field("dict_any_str", &PyClassForTestObj::dict_any_str)
-    .Field("dict_str_list_int", &PyClassForTestObj::dict_str_list_int)
-    .Field("opt_i64", &PyClassForTestObj::opt_i64)
-    .Field("opt_f64", &PyClassForTestObj::opt_f64)
-    .Field("opt_raw_ptr", &PyClassForTestObj::opt_raw_ptr)
-    .Field("opt_dtype", &PyClassForTestObj::opt_dtype)
-    .Field("opt_device", &PyClassForTestObj::opt_device)
-    .Field("opt_func", &PyClassForTestObj::opt_func)
-    .Field("opt_ulist", &PyClassForTestObj::opt_ulist)
-    .Field("opt_udict", &PyClassForTestObj::opt_udict)
-    .Field("opt_str", &PyClassForTestObj::opt_str)
-    .Field("opt_list_any", &PyClassForTestObj::opt_list_any)
-    .Field("opt_list_list_int", &PyClassForTestObj::opt_list_list_int)
-    .Field("opt_dict_any_any", &PyClassForTestObj::opt_dict_any_any)
-    .Field("opt_dict_str_any", &PyClassForTestObj::opt_dict_str_any)
-    .Field("opt_dict_any_str", &PyClassForTestObj::opt_dict_any_str)
-    .Field("opt_dict_str_list_int", &PyClassForTestObj::opt_dict_str_list_int)
-    .StaticFn("__init__", ::mlc::InitOf<PyClassForTestObj, int64_t, double, void*, DLDataType, DLDevice, ::mlc::Any, ::mlc::Func, ::mlc::List<::mlc::Any>, ::mlc::Dict<::mlc::Any, ::mlc::Any>, ::mlc::Str, ::mlc::Str, ::mlc::List<::mlc::Any>, ::mlc::List<::mlc::List<int64_t>>, ::mlc::Dict<::mlc::Any, ::mlc::Any>, ::mlc::Dict<::mlc::Str, ::mlc::Any>, ::mlc::Dict<::mlc::Any, ::mlc::Str>, ::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>, ::mlc::Optional<int64_t>, ::mlc::Optional<double>, ::mlc::Optional<void*>, ::mlc::Optional<DLDataType>, ::mlc::Optional<DLDevice>, ::mlc::Optional<::mlc::Func>, ::mlc::Optional<::mlc::List<::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>>, ::mlc::Optional<::mlc::Str>, ::mlc::Optional<::mlc::List<::mlc::Any>>, ::mlc::Optional<::mlc::List<::mlc::List<int64_t>>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Str>>, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>>>);
-};  // struct PyClassForTest
-}  // namespace test_dataclasses_prototype
+struct py_class : public ::mlc::ObjectRef {
+  MLC_DEF_OBJ_REF(_EXPORTS, py_class, py_classObj, ::mlc::ObjectRef)
+    .Field("bool_", &py_classObj::bool_)
+    .Field("i8", &py_classObj::i8)
+    .Field("i16", &py_classObj::i16)
+    .Field("i32", &py_classObj::i32)
+    .Field("i64", &py_classObj::i64)
+    .Field("f32", &py_classObj::f32)
+    .Field("f64", &py_classObj::f64)
+    .Field("raw_ptr", &py_classObj::raw_ptr)
+    .Field("dtype", &py_classObj::dtype)
+    .Field("device", &py_classObj::device)
+    .Field("any", &py_classObj::any)
+    .Field("func", &py_classObj::func)
+    .Field("ulist", &py_classObj::ulist)
+    .Field("udict", &py_classObj::udict)
+    .Field("str_", &py_classObj::str_)
+    .Field("str_readonly", &py_classObj::str_readonly)
+    .Field("list_any", &py_classObj::list_any)
+    .Field("list_list_int", &py_classObj::list_list_int)
+    .Field("dict_any_any", &py_classObj::dict_any_any)
+    .Field("dict_str_any", &py_classObj::dict_str_any)
+    .Field("dict_any_str", &py_classObj::dict_any_str)
+    .Field("dict_str_list_int", &py_classObj::dict_str_list_int)
+    .Field("opt_bool", &py_classObj::opt_bool)
+    .Field("opt_i64", &py_classObj::opt_i64)
+    .Field("opt_f64", &py_classObj::opt_f64)
+    .Field("opt_raw_ptr", &py_classObj::opt_raw_ptr)
+    .Field("opt_dtype", &py_classObj::opt_dtype)
+    .Field("opt_device", &py_classObj::opt_device)
+    .Field("opt_func", &py_classObj::opt_func)
+    .Field("opt_ulist", &py_classObj::opt_ulist)
+    .Field("opt_udict", &py_classObj::opt_udict)
+    .Field("opt_str", &py_classObj::opt_str)
+    .Field("opt_list_any", &py_classObj::opt_list_any)
+    .Field("opt_list_list_int", &py_classObj::opt_list_list_int)
+    .Field("opt_dict_any_any", &py_classObj::opt_dict_any_any)
+    .Field("opt_dict_str_any", &py_classObj::opt_dict_str_any)
+    .Field("opt_dict_any_str", &py_classObj::opt_dict_any_str)
+    .Field("opt_dict_str_list_int", &py_classObj::opt_dict_str_list_int)
+    .StaticFn("__init__", ::mlc::InitOf<py_classObj, bool, int64_t, int64_t, int64_t, int64_t, double, double, void*, DLDataType, DLDevice, ::mlc::Any, ::mlc::Func, ::mlc::List<::mlc::Any>, ::mlc::Dict<::mlc::Any, ::mlc::Any>, ::mlc::Str, ::mlc::Str, ::mlc::List<::mlc::Any>, ::mlc::List<::mlc::List<int64_t>>, ::mlc::Dict<::mlc::Any, ::mlc::Any>, ::mlc::Dict<::mlc::Str, ::mlc::Any>, ::mlc::Dict<::mlc::Any, ::mlc::Str>, ::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>, ::mlc::Optional<bool>, ::mlc::Optional<int64_t>, ::mlc::Optional<double>, ::mlc::Optional<void*>, ::mlc::Optional<DLDataType>, ::mlc::Optional<DLDevice>, ::mlc::Optional<::mlc::Func>, ::mlc::Optional<::mlc::List<::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>>, ::mlc::Optional<::mlc::Str>, ::mlc::Optional<::mlc::List<::mlc::Any>>, ::mlc::Optional<::mlc::List<::mlc::List<int64_t>>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::Any>>, ::mlc::Optional<::mlc::Dict<::mlc::Any, ::mlc::Str>>, ::mlc::Optional<::mlc::Dict<::mlc::Str, ::mlc::List<int64_t>>>>);
+};  // struct py_class
+}  // namespace testing
+}  // namespace mlc
 """.strip()
     actual = mlcd.prototype_cxx(PyClassForTest).strip()
     assert actual == expected

--- a/tests/python/test_dataclasses_serialize.py
+++ b/tests/python/test_dataclasses_serialize.py
@@ -1,5 +1,6 @@
 import json
 import pickle
+from typing import Optional
 
 import mlc
 
@@ -9,24 +10,61 @@ class ObjTest(mlc.PyClass):
     a: int
     b: float
     c: str
+    d: bool
+
+
+@mlc.dataclasses.py_class("mlc.testing.serialize_opt")
+class ObjTestOpt(mlc.PyClass):
+    a: Optional[int]
+    b: Optional[float]
+    c: Optional[str]
+    d: Optional[bool]
 
 
 def test_json() -> None:
-    obj = ObjTest(1, 2.0, "3")
+    obj = ObjTest(1, 2.0, "3", True)
     obj_json = obj.json()
     obj_json_dict = json.loads(obj_json)
     assert obj_json_dict["type_keys"] == ["mlc.testing.serialize", "int"]
-    assert obj_json_dict["values"] == ["3", [0, [1, 1], 2.0, 0]]
-    obj_from_json = ObjTest.from_json(obj_json)
+    assert obj_json_dict["values"] == ["3", [0, [1, 1], 2.0, 0, True]]
+    obj_from_json: ObjTest = ObjTest.from_json(obj_json)
     assert obj.a == obj_from_json.a
     assert obj.b == obj_from_json.b
     assert obj.c == obj_from_json.c
+    assert obj.d == obj_from_json.d
 
 
 def test_pickle() -> None:
-    obj = ObjTest(1, 2.0, "3")
+    obj = ObjTest(1, 2.0, "3", False)
     obj_pickle = pickle.dumps(obj)
     obj_from_pickle = pickle.loads(obj_pickle)
     assert obj.a == obj_from_pickle.a
     assert obj.b == obj_from_pickle.b
     assert obj.c == obj_from_pickle.c
+    assert obj.d == obj_from_pickle.d
+
+
+def test_json_opt_0() -> None:
+    obj = ObjTestOpt(1, 2.0, "3", True)
+    obj_json = obj.json()
+    obj_json_dict = json.loads(obj_json)
+    assert obj_json_dict["type_keys"] == ["mlc.testing.serialize_opt", "int"]
+    assert obj_json_dict["values"] == ["3", [0, [1, 1], 2.0, 0, True]]
+    obj_from_json: ObjTestOpt = ObjTestOpt.from_json(obj_json)
+    assert obj.a == obj_from_json.a
+    assert obj.b == obj_from_json.b
+    assert obj.c == obj_from_json.c
+    assert obj.d == obj_from_json.d
+
+
+def test_json_opt_1() -> None:
+    obj = ObjTestOpt(None, None, None, None)
+    obj_json = obj.json()
+    obj_json_dict = json.loads(obj_json)
+    assert obj_json_dict["type_keys"] == ["mlc.testing.serialize_opt"]
+    assert obj_json_dict["values"] == [[0, None, None, None, None]]
+    obj_from_json: ObjTestOpt = ObjTestOpt.from_json(obj_json)
+    assert obj.a == obj_from_json.a
+    assert obj.b == obj_from_json.b
+    assert obj.c == obj_from_json.c
+    assert obj.d == obj_from_json.d

--- a/tests/python/test_printer_ast.py
+++ b/tests/python/test_printer_ast.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     "doc,expected",
     [
         (mlcp.ast.Literal(None), "None"),
-        (mlcp.ast.Literal(True), "1"),
-        (mlcp.ast.Literal(False), "0"),
+        (mlcp.ast.Literal(True), "True"),
+        (mlcp.ast.Literal(False), "False"),
         (mlcp.ast.Literal("test"), '"test"'),
         (mlcp.ast.Literal(""), '""'),
         (mlcp.ast.Literal('""'), r'"\"\""'),
@@ -154,7 +154,7 @@ SPECIAL_OP_CASES = [
     (
         mlcp.ast.OperationKind.IfThenElse,
         [mlcp.ast.Literal(True), mlcp.ast.Literal("true"), mlcp.ast.Literal("false")],
-        '"true" if 1 else "false"',
+        '"true" if True else "false"',
     ),
     (
         mlcp.ast.OperationKind.IfThenElse,
@@ -622,13 +622,13 @@ def test_print_expr_stmt_doc() -> None:
         (
             None,
             """
-            assert 1
+            assert True
             """,
         ),
         (
             mlcp.ast.Literal("test message"),
             """
-            assert 1, "test message"
+            assert True, "test message"
             """,
         ),
     ],
@@ -967,7 +967,7 @@ else:
             "comment",
             """
 # comment
-while 1:
+while True:
     x = y
 """,
         ),
@@ -1000,7 +1000,7 @@ x  # comment
             mlcp.ast.Assert(mlcp.ast.Literal(True)),
             "comment",
             """
-assert 1  # comment
+assert True  # comment
             """,
         ),
         (


### PR DESCRIPTION
This PR introduces `bool` support across the stack, including:
- Boolean values in `Any`/`AnyView`
- `Ref<bool>` and `Optional<bool>`
- Boolean fields and `Optional<bool>` fields in C/Python dataclasses
- Proper JSON parsing for boolean values
- Serialization/deserialization with boolean values
- Structural equal/hash with boolean values
- Boolean literals in Printer AST