### PR TITLE
chore(release): Version Bump 0.1.1 => 0.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(
   mlc
-  VERSION 0.1.1
+  VERSION 0.1.2
   DESCRIPTION "MLC-Python"
   LANGUAGES C CXX
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlc-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
     'numpy >= 1.22',
     'ml-dtypes >= 0.1',


### PR DESCRIPTION
Bump `main` to v0.1.2 given v0.1.1 is officially released: https://github.com/mlc-ai/mlc-python/releases/tag/v0.1.1