### PR TITLE
fix(core): Backtrace Filtering

### DIFF
--- a/cpp/traceback.cc
+++ b/cpp/traceback.cc
@@ -1,6 +1,7 @@
 #ifndef _MSC_VER
 #include "./traceback.h"
 #include <backtrace.h>
+#include <cstring>
 #include <cxxabi.h>
 #include <iostream>
 #include <mlc/c_api.h>
@@ -11,7 +12,8 @@ namespace {
 
 static int32_t MLC_TRACEBACK_LIMIT = GetTracebackLimit();
 static backtrace_state *_bt_state = backtrace_create_state(
-    /*filename=*/nullptr,
+    /*filename=*/
+    nullptr,
     /*threaded=*/1,
     /*error_callback=*/
     +[](void * /*data*/, const char *msg, int /*errnum*/) -> void {
@@ -43,7 +45,8 @@ MLCByteArray TracebackImpl() {
     }
     if (!symbol) {
       backtrace_syminfo(
-          /*state=*/_bt_state, /*addr=*/pc, /*callback=*/
+          /*state=*/
+          _bt_state, /*addr=*/pc, /*callback=*/
           +[](void *data, uintptr_t /*pc*/, const char *symname, uintptr_t /*symval*/, uintptr_t /*symsize*/) {
             *reinterpret_cast<const char **>(data) = symname;
           },
@@ -54,11 +57,22 @@ MLCByteArray TracebackImpl() {
     if (IsForeignFrame(filename, lineno, symbol)) {
       return 1;
     }
-    reinterpret_cast<TracebackStorage *>(data)->Append(filename)->Append(lineno)->Append(symbol);
+    if (!EndsWith(filename, "core.pyx") &&       //
+        !EndsWith(filename, "func.h") &&         //
+        !EndsWith(filename, "func_details.h") && //
+        !EndsWith(filename, "mlc/core/all.h") && //
+        !EndsWith(filename, "mlc/base/all.h")    //
+    ) {
+      TracebackStorage *storage = reinterpret_cast<TracebackStorage *>(data);
+      storage->Append(filename);
+      storage->Append(lineno);
+      storage->Append(symbol);
+    }
     return 0;
   };
   backtrace_full(
-      /*state=*/_bt_state, /*skip=*/1, /*callback=*/callback,
+      /*state=*/
+      _bt_state, /*skip=*/1, /*callback=*/callback,
       /*error_callback=*/[](void * /*data*/, const char * /*msg*/, int /*errnum*/) {},
       /*data=*/&storage);
   return {static_cast<int64_t>(storage.buffer.size()), storage.buffer.data()};

--- a/include/mlc/printer/ir_printer.h
+++ b/include/mlc/printer/ir_printer.h
@@ -54,10 +54,14 @@ struct IRPrinterObj : public Object {
       Optional<Str> name = (*it).second->name;
       return Id(name.value());
     }
-    // Legalize characters in the name
-    for (char &c : name_hint) {
-      if (c != '_' && !std::isalnum(c)) {
-        c = '_';
+    bool needs_normalize =
+        std::any_of(name_hint->begin(), name_hint->end(), [](char c) { return c != '_' && !std::isalnum(c); });
+    if (needs_normalize) {
+      name_hint = Str(name_hint->c_str());
+      for (char &c : name_hint) {
+        if (c != '_' && !std::isalnum(c)) {
+          c = '_';
+        }
       }
     }
     // Find a unique name

--- a/python/mlc/_cython/base.py
+++ b/python/mlc/_cython/base.py
@@ -245,6 +245,7 @@ def translate_exception_to_c(exception: Exception) -> tuple[bytes, int, bytes]:
             bytes_info.append(str_py2c(code.co_filename))
             tb = tb.tb_next
         bytes_info.append(str_py2c(str(exception)))
+        bytes_info = [b if b else b"<null>" for b in bytes_info]
         bytes_info.reverse()
         bytes_info.append(b"")
         return b"\0".join(bytes_info)

--- a/tests/python/test_printer_ir_printer.py
+++ b/tests/python/test_printer_ir_printer.py
@@ -7,6 +7,12 @@ def test_var_print() -> None:
     assert mlcp.to_python(a) == "a"
 
 
+def test_var_print_name_normalize() -> None:
+    a = Var(name="a/0/b")
+    assert mlcp.to_python(a) == "a_0_b"
+    assert mlcp.to_python(a) == "a_0_b"
+
+
 def test_add_print() -> None:
     a = Var(name="a")
     b = Var(name="b")


### PR DESCRIPTION
This PR improves the stacktrace by:
1) Filter out unnecessary stack frames in `func.h`, `func_details.h`, etc;
2) Fix a bug when handling errors that have no error message, e.g. `NotImplementedError` 