### PR TITLE
fix(printer): Handle `Assign.lhs` being an empty tuple

### DIFF
--- a/tests/python/test_printer_ast.py
+++ b/tests/python/test_printer_ast.py
@@ -469,6 +469,17 @@ def test_print_stmt_block_doc(stmts: list[mlcp.ast.Stmt], expected: str) -> None
             ),
             "x, (y, z) = z",
         ),
+        (
+            mlcp.ast.Assign(
+                mlcp.ast.Tuple([]),
+                mlcp.ast.Operation(
+                    mlcp.ast.OperationKind.Add,
+                    [mlcp.ast.Id("x"), mlcp.ast.Id("y")],
+                ),
+                None,
+            ),
+            "x + y",
+        ),
     ],
     ids=itertools.count(),
 )


### PR DESCRIPTION
This PR fixes the behavior when `Assign.lhs` is `Tuple([])`. Previously, it would print:

```python
 = x + y
```

where ` = ` is unnecessary and wrong. This PR fixes this issue.