### PR TITLE
feat(core): Support Opaque Objects

### DIFF
--- a/cpp/c_api.cc
+++ b/cpp/c_api.cc
@@ -235,6 +235,7 @@ MLC_REGISTER_FUNC("mlc.testing.cxx_ptr").set_body([](void *x) -> void * { return
 MLC_REGISTER_FUNC("mlc.testing.cxx_dtype").set_body([](DLDataType x) { return x; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_device").set_body([](DLDevice x) { return x; });
 MLC_REGISTER_FUNC("mlc.testing.cxx_raw_str").set_body([](const char *x) { return x; });
+MLC_REGISTER_FUNC("mlc.testing.cxx_obj").set_body([](Object *x) { return x; });
 
 /**************** Reflection ****************/
 

--- a/cpp/traceback.cc
+++ b/cpp/traceback.cc
@@ -60,6 +60,7 @@ MLCByteArray TracebackImpl() {
     if (!EndsWith(filename, "core.pyx") &&       //
         !EndsWith(filename, "func.h") &&         //
         !EndsWith(filename, "func_details.h") && //
+        !EndsWith(filename, "visitor.h") &&      //
         !EndsWith(filename, "mlc/core/all.h") && //
         !EndsWith(filename, "mlc/base/all.h")    //
     ) {

--- a/include/mlc/c_api.h
+++ b/include/mlc/c_api.h
@@ -83,6 +83,7 @@ typedef enum {
   kMLCError = 1003,
   kMLCFunc = 1004,
   kMLCStr = 1005,
+  kMLCOpaque = 1007,
   kMLCCoreEnd = 1100,
   // }
   // kMLCTyping [1100: 1200) {
@@ -175,6 +176,13 @@ typedef struct {
   int64_t size;
   void *data;
 } MLCDict;
+
+typedef struct {
+  MLCAny _mlc_header;
+  void *handle;
+  MLCDeleterType handle_deleter;
+  const char *opaque_type_name;
+} MLCOpaque;
 
 typedef struct {
   MLCAny _mlc_header;

--- a/include/mlc/core/all.h
+++ b/include/mlc/core/all.h
@@ -7,6 +7,7 @@
 #include "./list.h"         // IWYU pragma: export
 #include "./object.h"       // IWYU pragma: export
 #include "./object_path.h"  // IWYU pragma: export
+#include "./opaque.h"       // IWYU pragma: export
 #include "./reflection.h"   // IWYU pragma: export
 #include "./str.h"          // IWYU pragma: export
 #include "./typing.h"       // IWYU pragma: export

--- a/include/mlc/core/opaque.h
+++ b/include/mlc/core/opaque.h
@@ -1,0 +1,40 @@
+#ifndef MLC_CORE_OPAQUE_H_
+#define MLC_CORE_OPAQUE_H_
+
+#include "./object.h"
+#include "./typing.h"
+#include <cstring>
+
+namespace mlc {
+
+struct OpaqueObj : public MLCOpaque {
+  explicit OpaqueObj(void *handle_, void *handle_deleter_, const char *opaque_type_name_) : MLCOpaque{} {
+    this->handle = handle_;
+    this->handle_deleter = reinterpret_cast<MLCDeleterType>(handle_deleter_);
+    this->opaque_type_name = [opaque_type_name_]() {
+      char *ret = new char[std::strlen(opaque_type_name_) + 1];
+      std::memcpy(ret, opaque_type_name_, std::strlen(opaque_type_name_) + 1);
+      return ret;
+    }();
+  }
+  ~OpaqueObj() {
+    delete[] this->opaque_type_name;
+    this->handle_deleter(this->handle);
+  }
+  std::string __str__() const { return "<Opaque `" + std::string(this->opaque_type_name) + "`>"; }
+  MLC_DEF_STATIC_TYPE(MLC_EXPORTS, OpaqueObj, Object, MLCTypeIndex::kMLCOpaque, "mlc.core.Opaque");
+};
+
+struct Opaque : public ObjectRef {
+  MLC_DEF_OBJ_REF(MLC_EXPORTS, Opaque, OpaqueObj, ObjectRef)
+      .StaticFn("__init__", InitOf<OpaqueObj, void *, void *, const char *>)
+      .MemFn("__str__", &OpaqueObj::__str__)
+      .FieldReadOnly("handle", &OpaqueObj::handle)
+      ._Field("handle_deleter", offsetof(MLCOpaque, handle_deleter), sizeof(MLCOpaque::handle_deleter), true,
+              ::mlc::core::ParseType<void *>())
+      .FieldReadOnly("opaque_type_name", &OpaqueObj::opaque_type_name);
+};
+
+} // namespace mlc
+
+#endif // MLC_CORE_OPAQUE_H_

--- a/include/mlc/core/typing.h
+++ b/include/mlc/core/typing.h
@@ -128,6 +128,7 @@ struct AtomicType : public Type {
 
 struct PtrTypeObj : protected MLCTypingPtr {
   explicit PtrTypeObj(Type ty) : MLCTypingPtr{} { this->TyMut() = ty; }
+  ~PtrTypeObj() { this->TyMut().~Type(); }
   ::mlc::Str __str__() const {
     std::ostringstream os;
     os << "Ptr[" << this->Ty() << "]";
@@ -156,6 +157,7 @@ struct PtrType : public Type {
 
 struct OptionalObj : protected MLCTypingOptional {
   explicit OptionalObj(Type ty) : MLCTypingOptional{} { this->TyMutable() = ty; }
+  ~OptionalObj() { this->TyMutable().~Type(); }
   ::mlc::Str __str__() const {
     std::ostringstream os;
     os << this->Ty() << " | None";
@@ -184,6 +186,7 @@ struct Optional : public Type {
 
 struct ListObj : protected MLCTypingList {
   explicit ListObj(Type ty) : MLCTypingList{} { this->TyMutable() = ty; }
+  ~ListObj() { this->TyMutable().~Type(); }
   ::mlc::Str __str__() const {
     std::ostringstream os;
     os << "list[" << this->Ty() << "]";
@@ -214,6 +217,10 @@ struct DictObj : protected MLCTypingDict {
   explicit DictObj(Type ty_k, Type ty_v) : MLCTypingDict{} {
     this->TyKMut() = ty_k;
     this->TyVMut() = ty_v;
+  }
+  ~DictObj() {
+    this->TyKMut().~Type();
+    this->TyVMut().~Type();
   }
   ::mlc::Str __str__() const {
     std::ostringstream os;

--- a/include/mlc/core/visitor.h
+++ b/include/mlc/core/visitor.h
@@ -4,6 +4,7 @@
 #include "./dict.h"
 #include "./list.h"
 #include "./object.h"
+#include "mlc/c_api.h"
 #include <functional>
 #include <mlc/base/all.h>
 #include <unordered_map>
@@ -271,10 +272,13 @@ inline void TopoVisit(Object *root, std::function<void(Object *object, MLCTypeIn
         FieldExtractor{&state, current}(nullptr, &kv.first);
         FieldExtractor{&state, current}(nullptr, &kv.second);
       }
-    } else if (int32_t type_index = current->type_info->type_index;
-               type_index == kMLCStr || type_index == kMLCFunc || type_index == kMLCError) {
     } else {
-      VisitFields(current->obj, current->type_info, FieldExtractor{&state, current});
+      int32_t type_index = current->type_info->type_index;
+      if (type_index == kMLCStr || type_index == kMLCFunc || type_index == kMLCError || type_index == kMLCOpaque) {
+        continue;
+      } else {
+        VisitFields(current->obj, current->type_info, FieldExtractor{&state, current});
+      }
     }
   }
   if (on_visit == nullptr) {

--- a/python/mlc/__init__.py
+++ b/python/mlc/__init__.py
@@ -9,6 +9,7 @@ from .core import (
     List,
     Object,
     ObjectPath,
+    Opaque,
     build_info,
     json_loads,
     typing,

--- a/python/mlc/_cython/__init__.py
+++ b/python/mlc/_cython/__init__.py
@@ -35,6 +35,8 @@ from .core import (  # type: ignore[import-not-found]
     func_init,
     func_register,
     make_mlc_init,
+    opaque_init,
+    register_opauqe_type,
     str_c2py,
     str_py2c,
     type_add_method,

--- a/python/mlc/core/__init__.py
+++ b/python/mlc/core/__init__.py
@@ -7,3 +7,4 @@ from .func import Func, build_info, json_loads
 from .list import List
 from .object import Object
 from .object_path import ObjectPath
+from .opaque import Opaque

--- a/python/mlc/core/opaque.py
+++ b/python/mlc/core/opaque.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mlc._cython import Ptr, c_class_core, opaque_init, register_opauqe_type
+
+from .object import Object
+
+
+@c_class_core("mlc.core.Opaque")
+class Opaque(Object):
+    handle: Ptr
+
+    def __init__(self, instance: Any) -> None:
+        opaque_init(self, instance)
+
+    @staticmethod
+    def register(ty: type) -> None:
+        register_opauqe_type(ty)

--- a/tests/python/test_core_opaque.py
+++ b/tests/python/test_core_opaque.py
@@ -1,0 +1,49 @@
+import mlc
+import pytest
+
+
+class MyType:
+    def __init__(self, a: int) -> None:
+        self.a = a
+
+
+class MyTypeNotRegistered:
+    def __init__(self, a: int) -> None:
+        self.a = a
+
+
+mlc.Opaque.register(MyType)
+
+
+def test_opaque_init() -> None:
+    a = MyType(a=10)
+    opaque = mlc.Opaque(a)
+    assert str(opaque) == "<Opaque `test_core_opaque.MyType`>"
+
+
+def test_opaque_init_error() -> None:
+    a = MyTypeNotRegistered(a=10)
+    with pytest.raises(TypeError) as e:
+        mlc.Opaque(a)
+    assert (
+        str(e.value)
+        == "MLC does not recognize type: <class 'test_core_opaque.MyTypeNotRegistered'>. "
+        "If it's intentional, please register using `mlc.Opaque.register(type)`."
+    )
+
+
+def test_opaque_ffi() -> None:
+    func = mlc.Func.get("mlc.testing.cxx_obj")
+    a = func(MyType(a=10))
+    assert isinstance(a, MyType)
+    assert a.a == 10
+
+
+def test_opaque_ffi_error() -> None:
+    func = mlc.Func.get("mlc.testing.cxx_obj")
+    with pytest.raises(TypeError) as e:
+        func(MyTypeNotRegistered(a=10))
+    assert (
+        str(e.value)
+        == "MLC does not recognize type: <class 'test_core_opaque.MyTypeNotRegistered'>"
+    )


### PR DESCRIPTION
This PR introduces `mlc.core.Opaque` to support passing opaque Python objects across MLC's cross-language dataclass infra.

Opaque types have to be registered via:

```python
mlc.Opaque.register(MyType)
```

and then can be directly passed into C++ via MLC's native FFI. If an `mlc.Opaque` is returned from C++ to Python, MLC's FFI will automatically unpacks it back to its original type.

Opaque types are not allowed in:
- Structural equal/hash;
- Serialization and deserialization;
- Deep copy.
