### PR TITLE
feat(core): Implement `Tensor.__dlpack__`

### DIFF
--- a/cpp/registry.h
+++ b/cpp/registry.h
@@ -653,6 +653,7 @@ inline TypeTable *TypeTable::New() {
   self->SetFunc("mlc.core.TensorFromBytes", Func(::mlc::registry::TensorFromBytes).get());
   self->SetFunc("mlc.core.TensorToBase64", Func(::mlc::registry::TensorToBase64).get());
   self->SetFunc("mlc.core.TensorFromBase64", Func(::mlc::registry::TensorFromBase64).get());
+  self->SetFunc("mlc.core.TensorToDLPack", Func([](TensorObj *tensor) -> void * { return tensor->DLPack(); }).get());
   self->SetFunc("mlc.printer.DocToPythonScript", Func(::mlc::registry::DocToPythonScript).get());
   self->SetFunc("mlc.printer.ToPython", Func(::mlc::printer::ToPython).get());
 

--- a/python/mlc/_cython/__init__.py
+++ b/python/mlc/_cython/__init__.py
@@ -47,6 +47,7 @@ from .core import (  # type: ignore[import-not-found]
     tensor_ndim,
     tensor_shape,
     tensor_strides,
+    tensor_to_dlpack,
     type_add_method,
     type_cast,
     type_create,

--- a/python/mlc/core/tensor.py
+++ b/python/mlc/core/tensor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from mlc._cython import (
     Ptr,
     c_class_core,
@@ -13,12 +15,15 @@ from mlc._cython import (
     tensor_ndim,
     tensor_shape,
     tensor_strides,
+    tensor_to_dlpack,
 )
 
 from .func import Func
 from .object import Object
 
 if TYPE_CHECKING:
+    import torch
+
     from mlc.core import DataType, Device
 
 
@@ -61,6 +66,20 @@ class Tensor(Object):
     @staticmethod
     def from_base64(base64: str) -> Tensor:
         return TensorFromBase64(base64)
+
+    def __dlpack__(self) -> Any:
+        return tensor_to_dlpack(self)
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        return self.device._device_pair
+
+    def numpy(self) -> np.ndarray:
+        return np.from_dlpack(self)
+
+    def torch(self) -> torch.Tensor:
+        import torch
+
+        return torch.from_dlpack(self)
 
 
 TensorToBase64 = Func.get("mlc.core.TensorToBase64")

--- a/tests/python/test_core_tensor.py
+++ b/tests/python/test_core_tensor.py
@@ -28,6 +28,8 @@ def test_tensor_from_numpy(cxx_func: mlc.Func) -> None:
     assert b.byte_offset == 0
     assert str(b) == "<mlc.Tensor int16[2, 3, 4] @ cpu:0>"
 
+    assert np.array_equal(a, b.numpy())
+
 
 def test_opaque_from_torch(cxx_func: mlc.Func) -> None:
     a = torch.arange(24, dtype=torch.int16).reshape(2, 3, 4)
@@ -47,6 +49,8 @@ def test_opaque_from_torch(cxx_func: mlc.Func) -> None:
     assert b.strides is None
     assert b.byte_offset == 0
     assert str(b) == "<mlc.Tensor int16[2, 3, 4] @ cpu:0>"
+
+    assert torch.equal(a, b.torch())
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
@@ -69,6 +73,8 @@ def test_opaque_from_torch_cuda(cxx_func: mlc.Func) -> None:
     assert b.byte_offset == 0
     assert str(b) == "<mlc.Tensor int16[2, 3, 4] @ cuda:0>"
 
+    assert torch.equal(a, b.torch())
+
 
 def test_tensor_serialize() -> None:
     a = mlc.Tensor(np.arange(24, dtype=np.int16).reshape(2, 3, 4))
@@ -80,3 +86,6 @@ def test_tensor_serialize() -> None:
     assert a.strides == b.strides
     assert a.byte_offset == b.byte_offset
     assert a.base64() == b.base64()
+
+    assert np.array_equal(a.numpy(), b.numpy())
+    assert torch.equal(a.torch(), b.torch())


### PR DESCRIPTION
This PR introduces two DLPack-compatible APIs:
- `Tensor.__dlpack__`
- `Tensor.__dlpack_device__`

Based on that, two additional convenient APIs are introduced:
- `Tensor.numpy()` which converts MLC's Tensor to numpy's ndarray
- `Tensor.torch()` which converts MLC's Tensor to torch's tensor.