### PR TITLE
fix(core): always check error code from libmlc

### DIFF
--- a/cpp/c_api.cc
+++ b/cpp/c_api.cc
@@ -54,7 +54,7 @@ thread_local Any last_error;
 
 MLC_API MLCAny MLCGetLastError() {
   MLCAny ret;
-  *static_cast<Any *>(&ret) = std::move(last_error);
+  static_cast<Any &>(ret) = std::move(last_error);
   return ret;
 }
 
@@ -99,6 +99,20 @@ MLC_API int32_t MLCTypeAddMethod(MLCTypeTableHandle _self, int32_t type_index, M
   MLC_SAFE_CALL_END(&last_error);
 }
 
+MLC_API int32_t MLCVTableCreate(MLCTypeTableHandle _self, const char *key, MLCVTableHandle *ret) {
+  MLC_SAFE_CALL_BEGIN();
+  *ret = new mlc::registry::MLCVTable(TypeTable::Get(_self), key);
+  MLC_SAFE_CALL_END(&last_error);
+}
+
+MLC_API int32_t MLCVTableDelete(MLCVTableHandle self) {
+  MLC_SAFE_CALL_BEGIN();
+  if (self) {
+    delete static_cast<mlc::registry::MLCVTable *>(self);
+  }
+  MLC_SAFE_CALL_END(&last_error);
+}
+
 MLC_API int32_t MLCVTableGetGlobal(MLCTypeTableHandle _self, const char *key, MLCVTableHandle *ret) {
   MLC_SAFE_CALL_BEGIN();
   *ret = TypeTable::Get(_self)->GetGlobalVTable(key);
@@ -106,16 +120,23 @@ MLC_API int32_t MLCVTableGetGlobal(MLCTypeTableHandle _self, const char *key, ML
 }
 
 MLC_API int32_t MLCVTableGetFunc(MLCVTableHandle vtable, int32_t type_index, int32_t allow_ancestor, MLCAny *ret) {
-  using ::mlc::registry::VTable;
+  using ::mlc::registry::MLCVTable;
   MLC_SAFE_CALL_BEGIN();
-  *static_cast<Any *>(ret) = static_cast<VTable *>(vtable)->GetFunc(type_index, allow_ancestor);
+  *static_cast<Any *>(ret) = static_cast<MLCVTable *>(vtable)->GetFunc(type_index, allow_ancestor);
   MLC_SAFE_CALL_END(&last_error);
 }
 
 MLC_API int32_t MLCVTableSetFunc(MLCVTableHandle vtable, int32_t type_index, MLCFunc *func, int32_t override_mode) {
-  using ::mlc::registry::VTable;
+  using ::mlc::registry::MLCVTable;
   MLC_SAFE_CALL_BEGIN();
-  static_cast<VTable *>(vtable)->Set(type_index, static_cast<FuncObj *>(func), override_mode);
+  static_cast<MLCVTable *>(vtable)->Set(type_index, static_cast<FuncObj *>(func), override_mode);
+  MLC_SAFE_CALL_END(&last_error);
+}
+
+MLC_API int32_t MLCVTableCall(MLCVTableHandle vtable, int32_t num_args, MLCAny *args, MLCAny *ret) {
+  using ::mlc::registry::MLCVTable;
+  MLC_SAFE_CALL_BEGIN();
+  static_cast<MLCVTable *>(vtable)->Call(num_args, args, ret);
   MLC_SAFE_CALL_END(&last_error);
 }
 

--- a/include/mlc/base/utils.h
+++ b/include/mlc/base/utils.h
@@ -77,6 +77,11 @@
   }                                                                                                                    \
   MLC_UNREACHABLE()
 
+#define MLC_CHECK_ERR(Call, Ret)                                                                                       \
+  if (int32_t err_code = (Call)) {                                                                                     \
+    ::mlc::base::FuncCallCheckError(err_code, (Ret));                                                                  \
+  }
+
 namespace mlc {
 namespace base {
 
@@ -108,6 +113,7 @@ struct ErrorBuilder {
 
 StrObj *StrCopyFromCharArray(const char *source, size_t length);
 void FuncCall(const void *func, int32_t num_args, const MLCAny *args, MLCAny *ret);
+void FuncCallCheckError(int32_t err_code, MLCAny *ret) noexcept(false);
 template <typename Callable> Any CallableToAny(Callable &&callable);
 template <typename DerivedType, typename SelfType = Object> bool IsInstanceOf(const MLCAny *self);
 

--- a/include/mlc/c_api.h
+++ b/include/mlc/c_api.h
@@ -284,6 +284,9 @@ MLC_API int32_t MLCTypeRegisterStructure(MLCTypeTableHandle self, int32_t type_i
                                          int64_t num_sub_structures, int32_t *sub_structure_indices,
                                          int32_t *sub_structure_kinds);
 MLC_API int32_t MLCTypeAddMethod(MLCTypeTableHandle self, int32_t type_index, MLCTypeMethod method);
+MLC_API int32_t MLCVTableCreate(MLCTypeTableHandle self, const char *key, MLCVTableHandle *ret);
+MLC_API int32_t MLCVTableDelete(MLCVTableHandle self);
+MLC_API int32_t MLCVTableCall(MLCVTableHandle vtable, int32_t num_args, MLCAny *args, MLCAny *ret);
 MLC_API int32_t MLCVTableGetGlobal(MLCTypeTableHandle self, const char *key, MLCVTableHandle *ret);
 MLC_API int32_t MLCVTableGetFunc(MLCVTableHandle vtable, int32_t type_index, int32_t allow_ancestor, MLCAny *ret);
 MLC_API int32_t MLCVTableSetFunc(MLCVTableHandle vtable, int32_t type_index, MLCFunc *func, int32_t override_mode);

--- a/include/mlc/core/func_details.h
+++ b/include/mlc/core/func_details.h
@@ -190,16 +190,12 @@ template <typename FuncType, typename> MLC_INLINE FuncObj *FuncObj::Allocator::N
 inline Ref<FuncObj> FuncObj::FromForeign(void *self, MLCDeleterType deleter, MLCFuncSafeCallType safe_call) {
   if (deleter == nullptr) {
     return Ref<FuncObj>::New([self, safe_call](int32_t num_args, const MLCAny *args, MLCAny *ret) {
-      if (int32_t err_code = safe_call(self, num_args, args, ret); err_code != 0) {
-        ::mlc::core::HandleSafeCallError(err_code, ret);
-      }
+      MLC_CHECK_ERR(safe_call(self, num_args, args, ret), ret);
     });
   } else {
     return Ref<FuncObj>::New(
         [self = std::shared_ptr<void>(self, deleter), safe_call](int32_t num_args, const MLCAny *args, MLCAny *ret) {
-          if (int32_t err_code = safe_call(self.get(), num_args, args, ret); err_code != 0) {
-            ::mlc::core::HandleSafeCallError(err_code, ret);
-          }
+          MLC_CHECK_ERR(safe_call(self.get(), num_args, args, ret), ret);
         });
   }
 }

--- a/include/mlc/core/reflection.h
+++ b/include/mlc/core/reflection.h
@@ -100,12 +100,14 @@ struct _Reflect {
                                                  reinterpret_cast<MLCFunc *>(func_any_to_ref.v.v_obj), //
                                                  kStaticFn});
       }
-      MLCTypeRegisterFields(nullptr, this->type_index, this->fields.size(), this->fields.data());
-      MLCTypeRegisterStructure(nullptr, this->type_index, static_cast<int32_t>(this->structure_kind),
-                               this->sub_structure_indices.size(), this->sub_structure_indices.data(),
-                               this->sub_structure_kinds.data());
+      MLC_CHECK_ERR(::MLCTypeRegisterFields(nullptr, this->type_index, this->fields.size(), this->fields.data()),
+                    nullptr);
+      MLC_CHECK_ERR(::MLCTypeRegisterStructure(nullptr, this->type_index, static_cast<int32_t>(this->structure_kind),
+                                               this->sub_structure_indices.size(), this->sub_structure_indices.data(),
+                                               this->sub_structure_kinds.data()),
+                    nullptr);
       for (const MLCTypeMethod &method : this->methods) {
-        MLCTypeAddMethod(nullptr, this->type_index, method);
+        MLC_CHECK_ERR(::MLCTypeAddMethod(nullptr, this->type_index, method), nullptr);
       }
     }
     return 0;


### PR DESCRIPTION
This PR introduces a macro `MLC_CHECK_ERR`, which is always used when accessing MLC's C APIs to make sure errors are always caught in time.