### PR TITLE
feat(core): Introduce `MLC_DEF_OBJ_REF_COW_`

### DIFF
--- a/include/mlc/base/ref.h
+++ b/include/mlc/base/ref.h
@@ -107,6 +107,7 @@ public:
   using TObj = _TObj;
   using TSelf = Ref<TObj>;
   [[maybe_unused]] static constexpr ::mlc::base::TypeKind _type_kind = ::mlc::base::TypeKind::kRef;
+  using ::mlc::base::PtrBase::Swap;
 
 private:
   using TBase = ::mlc::base::PtrBase;

--- a/include/mlc/base/utils.h
+++ b/include/mlc/base/utils.h
@@ -222,6 +222,18 @@ MLC_INLINE void DecRef(MLCAny *obj) {
   }
 }
 
+MLC_INLINE int32_t RefCount(MLCAny *obj) {
+  if (obj == nullptr) {
+    return 0;
+  }
+#ifdef _MSC_VER
+  return static_cast<int32_t>(_InterlockedCompareExchange(reinterpret_cast<volatile long *>(&obj->ref_cnt), 0, 0));
+#else
+  // acquire semantics to ensure visibility of the object
+  return static_cast<int32_t>(__atomic_load_n(&obj->ref_cnt, __ATOMIC_ACQUIRE));
+#endif
+}
+
 MLC_INLINE int32_t CountLeadingZeros(uint64_t x) {
 #if __cplusplus >= 202002L
   return std::countl_zero(x);


### PR DESCRIPTION
Inherited from TVM, `CopyOnWrite` method is applied on an `ObjectRef`, which, copies the underlying object an `ObjectRef` points to if for `ref_count > 1`. It's not strictly necessary in any cases, but will be useful to maintain certain level of API compatibility with TVM