### PR TITLE
feat(dataclass): Support `frozen=True` in py_class

### DIFF
--- a/python/mlc/_cython/base.py
+++ b/python/mlc/_cython/base.py
@@ -377,6 +377,10 @@ def attach_field(
     def fset(this: typing.Any, value: typing.Any, _name: str = name) -> None:
         setter(this, value)  # type: ignore[misc]
 
+    fget.__name__ = fset.__name__ = name
+    fget.__module__ = fset.__module__ = cls.__module__
+    fget.__qualname__ = fset.__qualname__ = f"{cls.__qualname__}.{name}"  # type: ignore[attr-defined]
+    fget.__doc__ = fset.__doc__ = f"Property `{name}` of class `{cls.__qualname__}`"  # type: ignore[attr-defined]
     prop = property(
         fget=fget if getter else None,
         fset=fset if (not frozen) and setter else None,

--- a/python/mlc/dataclasses/c_class.py
+++ b/python/mlc/dataclasses/c_class.py
@@ -39,7 +39,7 @@ def c_class(
 
         if type_info.type_cls is not None:
             raise ValueError(f"Type is already registered: {type_key}")
-        _, d_fields = inspect_dataclass_fields(type_key, type_cls, parent_type_info)
+        _, d_fields = inspect_dataclass_fields(type_key, type_cls, parent_type_info, frozen=False)
         type_info.type_cls = type_cls
         type_info.d_fields = tuple(d_fields)
 

--- a/python/mlc/dataclasses/py_class.py
+++ b/python/mlc/dataclasses/py_class.py
@@ -49,6 +49,7 @@ def py_class(
     *,
     init: bool = True,
     repr: bool = True,
+    frozen: bool = False,
     structure: typing.Literal["bind", "nobind", "var"] | None = None,
 ) -> Callable[[type[ClsType]], type[ClsType]]:
     if isinstance(type_key, type):
@@ -86,6 +87,7 @@ def py_class(
             type_key,
             super_type_cls,
             parent_type_info,
+            frozen=frozen,
         )
         num_bytes = _add_field_properties(fields)
         type_info.fields = tuple(fields)

--- a/python/mlc/dataclasses/utils.py
+++ b/python/mlc/dataclasses/utils.py
@@ -124,6 +124,7 @@ def inspect_dataclass_fields(  # noqa: PLR0912
     type_key: str,
     type_cls: type,
     parent_type_info: TypeInfo,
+    frozen: bool,
 ) -> tuple[list[TypeField], list[Field]]:
     def _get_num_bytes(field_ty: Any) -> int:
         if hasattr(field_ty, "_ctype"):
@@ -136,6 +137,7 @@ def inspect_dataclass_fields(  # noqa: PLR0912
     for type_field in parent_type_info.fields:
         field_name = type_field.name
         field_ty = type_field.ty
+        field_frozen = type_field.frozen
         if type_hints.pop(field_name, None) is None:
             raise ValueError(
                 f"Missing field `{type_key}::{field_name}`, "
@@ -146,7 +148,7 @@ def inspect_dataclass_fields(  # noqa: PLR0912
                 name=field_name,
                 offset=-1,
                 num_bytes=_get_num_bytes(field_ty),
-                frozen=False,
+                frozen=field_frozen,
                 ty=field_ty,
             )
         )
@@ -159,7 +161,7 @@ def inspect_dataclass_fields(  # noqa: PLR0912
                 name=field_name,
                 offset=-1,
                 num_bytes=_get_num_bytes(field_ty),
-                frozen=False,
+                frozen=frozen,
                 ty=field_ty,
             )
         )


### PR DESCRIPTION
This PR brings support for `frozen=True` so that one could create dataclass instances with immutability. For example,

```python
import mlc.dataclasses as mlcd

@mlcd.py_class(frozen=True)
class Frozen(mlcd.PyClass):
    a: int
    b: str

x = Frozen(a=1, b="b")

>>> x.a = 2  # not allowed to set a field
AttributeError: property 'a' of 'Frozen' object has no setter
```

And if one has to forcefully set attributes, there's a private API:

```python
>>> x._mlc_setattr("a", 3)
>>> x.a
3
```

This design is consistent with python's [native dataclass](https://docs.python.org/3/library/dataclasses.html#frozen-instances), where it uses `object.__setattr__` to force-set fields