### PR TITLE
chore(release): Add dependency to stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
         with:
           name: wheels-macos-x86
           path: ./wheelhouse/*.whl
-  linux:
-    name: Linux
+  linux-x86:
+    name: Linux-x86
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +110,7 @@ jobs:
           name: wheels-linux-x86
           path: ./wheelhouse/*.whl
   linux-arm:
-    name: Linux
+    name: Linux-arm
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: [windows, macos, linux, macos-x86]
+    needs: [windows, macos, macos-x86, linux-x86, linux-arm]
     environment:
       name: pypi
       url: https://pypi.org/p/mlc-python


### PR DESCRIPTION
Add an extra dependency edge from `linux-arm` to `publish`.

This makes the diagram look better. Lacking this dependency is totally fine though, because GitHub requires us to manually confirm before starting the publish process already.
