### PR TITLE
feat(core): Dependency Graph

### DIFF
--- a/cpp/c_api.cc
+++ b/cpp/c_api.cc
@@ -1,3 +1,4 @@
+#include "./dep_graph.h"
 #include "./registry.h"
 #include <mlc/core/all.h>
 

--- a/cpp/dep_graph.h
+++ b/cpp/dep_graph.h
@@ -1,0 +1,430 @@
+#ifndef MLC_CORE_DEP_GRAPH_H_
+#define MLC_CORE_DEP_GRAPH_H_
+
+#include <mlc/core/all.h>
+
+namespace mlc {
+namespace core {
+
+/*!
+ * \brief A dependency node in the dependency graph, which contains
+ * information about the statement, its input and output vars, and
+ * pointers to the previous and next nodes in the linked list.
+ * All the nodes are linked together in a doubly linked list.
+ */
+struct DepNodeObj {
+  MLCAny _mlc_header;
+  /*! \brief The statement that this node represents */
+  Any stmt;
+  /*! \brief The list of input variables for this node */
+  UList input_vars;
+  /*! \brief The list of output variables for this node */
+  UList output_vars;
+  /*! \brief The previous node in the linked list */
+  DepNodeObj *prev;
+  /*! \brief The next node in the linked list */
+  DepNodeObj *next;
+
+  MLC_DEF_DYN_TYPE(MLC_EXPORTS, DepNodeObj, Object, "mlc.core.DepNode");
+
+  explicit DepNodeObj(Any stmt, UList input_vars, UList output_vars, DepNodeObj *prev, DepNodeObj *next)
+      : stmt(stmt), input_vars(input_vars), output_vars(output_vars), prev(prev), next(next) {}
+
+  void Clear() {
+    this->stmt = Null;
+    this->input_vars.clear();
+    this->output_vars.clear();
+    this->prev = nullptr;
+    this->next = nullptr;
+  }
+};
+
+struct DepNode : public ObjectRef {
+  explicit DepNode(Any stmt, UList input_vars, UList output_vars)
+      : DepNode(DepNode::New(stmt, input_vars, output_vars, nullptr, nullptr)) {}
+
+  MLC_DEF_OBJ_REF(MLC_EXPORTS, DepNode, DepNodeObj, ObjectRef)
+      .Field("stmt", &DepNodeObj::stmt, /*frozen=*/true)
+      .Field("input_vars", &DepNodeObj::input_vars, /*frozen=*/true)
+      .Field("output_vars", &DepNodeObj::output_vars, /*frozen=*/true)
+      ._Field("_prev", offsetof(DepNodeObj, prev), sizeof(DepNodeObj *), true, ::mlc::core::ParseType<ObjectRef>())
+      ._Field("_next", offsetof(DepNodeObj, next), sizeof(DepNodeObj *), true, ::mlc::core::ParseType<ObjectRef>())
+      .StaticFn("__init__", InitOf<DepNodeObj, Any, UList, UList, DepNodeObj *, DepNodeObj *>);
+};
+
+struct DepGraphObj {
+  MLCAny _mlc_header;
+  /*! \brief A function that maps a stmt to a list of variables it consumes */
+  Func stmt_to_inputs;
+  /*! \brief A function that maps a stmt to a list of variables it produces */
+  Func stmt_to_outputs;
+  /*! \brief A map from a stmt to its node in the linked list */
+  UDict stmt_to_node;
+  /*! \brief Map from a variable to its producer nodes */
+  UDict var_to_producer;
+  /*! \brief Map from a variable to a list of consumer nodes */
+  UDict var_to_consumers;
+  /*! \brief The first node in the linked list */
+  DepNode head;
+
+  MLC_DEF_DYN_TYPE(MLC_EXPORTS, DepGraphObj, Object, "mlc.core.DepGraph");
+
+  explicit DepGraphObj(Func stmt_to_inputs, Func stmt_to_outputs, UDict stmt_to_node, UDict var_to_producer,
+                       UDict var_to_consumers, DepNode head)
+      : stmt_to_inputs(stmt_to_inputs), stmt_to_outputs(stmt_to_outputs), stmt_to_node(stmt_to_node),
+        var_to_producer(var_to_producer), var_to_consumers(var_to_consumers), head(head) {}
+
+  explicit DepGraphObj(UList input_vars, UList stmts, Func stmt_to_inputs, Func stmt_to_outputs)
+      : stmt_to_inputs(stmt_to_inputs), stmt_to_outputs(stmt_to_outputs), stmt_to_node(), var_to_producer(),
+        var_to_consumers(), head(DepNode(Any(), UList{}, input_vars)) {
+    this->stmt_to_node[Any()] = this->head;
+    for (const Any &var : input_vars) {
+      this->var_to_producer[var] = this->head;
+      this->var_to_consumers[var] = UList{};
+    }
+    DepNodeObj *prev = this->head.get();
+    for (const Any &stmt : stmts) {
+      DepNode node = this->CreateNode(stmt);
+      this->InsertAfter(prev, node.get());
+      prev = node.get();
+    }
+  }
+
+  ~DepGraphObj() { this->Clear(); }
+
+  /*!
+   * \brief Clear the dependency graph.
+   * \note This will unlink all nodes from the graph and clear the maps.
+   */
+  void Clear() {
+    for (DepNodeObj *node = this->head.get(); node;) {
+      DepNodeObj *next = node->next;
+      node->Clear();
+      node = next;
+    }
+    this->var_to_producer.clear();
+    this->var_to_consumers.clear();
+    this->stmt_to_node.clear();
+  }
+  /*!
+   * \brief Create a new node which is not linked to the dependency graph.
+   * \param stmt The statement that this node represents
+   * \return The new node
+   * \note This node is not part of the dependency graph until it's explicitly
+   *       inserted using InsertBefore or InsertAfter.
+   */
+  DepNode CreateNode(Any stmt) { return DepNode(stmt, this->stmt_to_inputs(stmt), this->stmt_to_outputs(stmt)); }
+  /*!
+   * \brief Get a node containing the given statement
+   * \param stmt The statement to get the node for
+   * \return The node containing the statement
+   * \note This will throw an error if the statement is not inserted into the graph.
+   */
+  DepNode GetNodeFromStmt(Any stmt) {
+    if (auto it = this->stmt_to_node.find(stmt); it != this->stmt_to_node.end()) {
+      return it->second;
+    }
+    MLC_THROW(RuntimeError) << "Stmt not in graph: " << stmt;
+    MLC_UNREACHABLE();
+  }
+  /*!
+   * \brief Insert a node before or after an anchor node.
+   * \param anchor The anchor node, not nullptr
+   * \param to_insert The node to insert
+   * \note This will link the new node to the dependency graph.
+   */
+  void InsertBefore(DepNodeObj *anchor, DepNodeObj *to_insert) {
+    if (anchor->prev == nullptr) {
+      MLC_THROW(RuntimeError) << "Can't input before the input node: " << anchor->stmt;
+    }
+    if (!stmt_to_node.count(anchor->stmt)) {
+      MLC_THROW(RuntimeError) << "Anchor node not in graph: " << anchor->stmt;
+    }
+    DepNodeObj *prev = anchor->prev;
+    DepNodeObj *next = anchor;
+    return _Insert(prev, next, to_insert);
+  }
+  /*!
+   * \brief Insert a node before or after an anchor node.
+   * \param anchor The anchor node, not nullptr
+   * \param to_insert The node to insert
+   * \note This will link the new node to the dependency graph.
+   */
+  void InsertAfter(DepNodeObj *anchor, DepNodeObj *to_insert) {
+    if (!stmt_to_node.count(anchor->stmt)) {
+      MLC_THROW(RuntimeError) << "Anchor node not in graph: " << anchor->stmt;
+    }
+    DepNodeObj *prev = anchor;
+    DepNodeObj *next = anchor->next;
+    return _Insert(prev, next, to_insert);
+  }
+  /*!
+   * \brief Erase a node from the dependency graph.
+   * \param to_erase The node to erase, not nullptr
+   * \note This will unlink the node from the dependency graph, remove the variables
+   *       it produces, and remove itself from the consumer lists of the variables it consumes.
+   */
+  void EraseNode(DepNodeObj *to_erase) {
+    // Step 1. Unlink the node from the graph
+    if (to_erase->prev == nullptr) {
+      MLC_THROW(RuntimeError) << "Can't erase the input node: " << to_erase->stmt;
+    }
+    if (!this->stmt_to_node.count(to_erase->stmt)) {
+      MLC_THROW(RuntimeError) << "Node not in graph: " << to_erase->stmt;
+    }
+    this->stmt_to_node.erase(to_erase->stmt);
+    if (to_erase->prev != nullptr) {
+      to_erase->prev->next = to_erase->next;
+    } else {
+      this->head = to_erase->next;
+    }
+    if (to_erase->next != nullptr) {
+      to_erase->next->prev = to_erase->prev;
+    }
+    // Step 2. For each variable produced by the node
+    // 1) check all its consumers are gone
+    // 2) remove the producer
+    for (const Any &var : to_erase->output_vars) {
+      UListObj *consumers = this->var_to_consumers.at(var);
+      if (!consumers->empty()) {
+        MLC_THROW(RuntimeError) << "Removing a node which produces a variable that still has consumers in graph: "
+                                << var;
+      }
+      this->var_to_producer.erase(var);
+      this->var_to_consumers.erase(var);
+    }
+    // Step 3. For each varibale consumed by the node
+    // 1) check if the var is in the graph
+    // 2) remove the node from its consumer list
+    for (const Any &var : to_erase->input_vars) {
+      if (!this->var_to_producer.count(var)) {
+        MLC_THROW(RuntimeError) << "Variable is not produced by any node in the graph: " << var;
+      }
+      UListObj *consumers = this->var_to_consumers.at(var);
+      auto it = std::find_if(consumers->begin(), consumers->end(),
+                             [to_erase](const Any &v) -> bool { return v.operator DepNodeObj *() == to_erase; });
+      if (it == consumers->end()) {
+        MLC_THROW(RuntimeError) << "Node is not a consumer of the variable: " << var;
+      }
+      consumers->erase(it);
+    }
+    // Step 4. Clear the node
+    to_erase->Clear();
+  }
+  /*!
+   * \brief Replace a node in the dependency graph with another node.
+   * \param old_node The node to replace
+   * \param new_node The new node to insert
+   * \note This will unlink the old node from the dependency graph and link the new node.
+   */
+  void Replace(DepNodeObj *old_node, DepNodeObj *new_node) {
+    if (old_node == new_node) {
+      return;
+    }
+    if (old_node->prev == nullptr) {
+      MLC_THROW(RuntimeError) << "Can't replace the input node: " << old_node->stmt;
+    }
+    if (!this->stmt_to_node.count(old_node->stmt)) {
+      MLC_THROW(RuntimeError) << "Node not in graph: " << old_node->stmt;
+    }
+    if (new_node->prev != nullptr || new_node->next != nullptr) {
+      MLC_THROW(RuntimeError) << "Node is already in the graph: " << new_node->stmt;
+    }
+    int64_t num_output_vars = old_node->output_vars.size();
+    if (num_output_vars != new_node->output_vars.size()) {
+      MLC_THROW(RuntimeError) << "Mismatched number of output_vars: " << num_output_vars << " vs "
+                              << new_node->output_vars.size();
+    }
+    // Step 1. Replace each variable produced by the old node
+    for (int64_t i = 0; i < num_output_vars; ++i) {
+      Any old_var = old_node->output_vars[i];
+      Any new_var = new_node->output_vars[i];
+      Ref<UListObj> old_var_consumers = var_to_consumers.at(old_var);
+      // Search through its consumers
+      for (DepNodeObj *consumer : *old_var_consumers) {
+        // Replace the input vars of each consumer
+        for (Any &v : consumer->input_vars) {
+          if (v.operator Object *() == old_var.operator Object *()) {
+            v = new_var;
+          }
+        }
+      }
+      this->var_to_producer.erase(old_var);
+      this->var_to_consumers.erase(old_var);
+      this->var_to_producer[new_var] = new_node;
+      this->var_to_consumers[new_var] = old_var_consumers;
+    }
+    // Step 2. Delete each variable consumed by the old node
+    for (const Any &var : old_node->input_vars) {
+      UListObj *consumers = this->var_to_consumers.at(var);
+      if (auto it = std::find_if(consumers->begin(), consumers->end(),
+                                 [old_node](const Any &v) -> bool { return v.operator DepNodeObj *() == old_node; });
+          it != consumers->end()) {
+        consumers->erase(it);
+      } else {
+        MLC_THROW(RuntimeError) << "Node is not a consumer of the variable: " << var;
+      }
+    }
+    // Step 3. Add variables consumed by the new node
+    for (const Any &var : new_node->input_vars) {
+      if (!this->var_to_producer.count(var)) {
+        MLC_THROW(RuntimeError) << "Variable is not produced by any node in the graph: " << var;
+      }
+      this->var_to_consumers.at(var).operator UListObj *()->push_back(new_node);
+    }
+    // Step 4. Link the new node into the graph
+    new_node->prev = old_node->prev;
+    new_node->next = old_node->next;
+    if (old_node->prev != nullptr) {
+      old_node->prev->next = new_node;
+    } else {
+      this->head = new_node;
+    }
+    if (old_node->next != nullptr) {
+      old_node->next->prev = new_node;
+    }
+    this->stmt_to_node.erase(old_node->stmt);
+    if (this->stmt_to_node.count(new_node->stmt)) {
+      MLC_THROW(RuntimeError) << "Stmt already in the graph: " << new_node->stmt;
+    } else {
+      this->stmt_to_node[new_node->stmt] = new_node;
+    }
+    // Step 5. Clear the old node
+    old_node->Clear();
+  }
+  /*!
+   * \brief For a given node, returns its producers, i.e. a list of nodes that produce the input variables of the node.
+   * \param node The node to get the input statements for
+   * \return The list of input nodes for the node
+   */
+  UList GetNodeProducers(DepNodeObj *node) {
+    UList ret;
+    for (const Any &var : node->input_vars) {
+      if (auto it = this->var_to_producer.find(var); it != this->var_to_producer.end()) {
+        ret.push_back(it->second);
+      } else {
+        MLC_THROW(RuntimeError) << "Variable is not produced by any node in the graph: " << var;
+      }
+    }
+    return ret;
+  }
+  /*!
+   * \brief For a given node, returns its consumers, i.e. a list of nodes that consume the output variables of the node.
+   * \param node The node to get the output statements for
+   * \return The list of output statements for the node
+   */
+  UList GetNodeConsumers(DepNodeObj *node) {
+    UList ret;
+    for (const Any &var : node->output_vars) {
+      if (auto it = this->var_to_consumers.find(var); it != this->var_to_consumers.end()) {
+        UListObj *consumers = it->second;
+        ret.insert(ret.end(), consumers->begin(), consumers->end());
+      } else {
+        MLC_THROW(RuntimeError) << "Variable is not consumed by any node in the graph: " << var;
+      }
+    }
+    return ret;
+  }
+  /*!
+   * \brief Find the producer of a variable in the dependency graph.
+   * \param var The variable to find the producer for
+   * \return The producer node for the variable
+   */
+  DepNode GetVarProducer(Any var) {
+    if (auto it = this->var_to_producer.find(var); it != this->var_to_producer.end()) {
+      return it->second;
+    }
+    MLC_THROW(RuntimeError) << "Variable is not produced by any node in the graph: " << var;
+    MLC_UNREACHABLE();
+  }
+  /*!
+   * \brief Find the consumers of a variable in the dependency graph.
+   * \param var The variable to find the consumers for
+   * \return The list of consumer nodes for the variable
+   */
+  UList GetVarConsumers(Any var) {
+    if (auto it = this->var_to_consumers.find(var); it != this->var_to_consumers.end()) {
+      return it->second;
+    }
+    MLC_THROW(RuntimeError) << "Variable is not consumed by any node in the graph: " << var;
+    MLC_UNREACHABLE();
+  }
+
+  void _Insert(DepNodeObj *prev, DepNodeObj *next, DepNodeObj *to_insert) {
+    if (to_insert->prev != nullptr || to_insert->next != nullptr) {
+      MLC_THROW(RuntimeError) << "Node is already in the graph: " << to_insert->stmt;
+    }
+    // Step 1. Link the node into the graph
+    if (this->stmt_to_node.count(to_insert->stmt)) {
+      MLC_THROW(RuntimeError) << "Stmt already in the graph: " << to_insert->stmt;
+    }
+    this->stmt_to_node[to_insert->stmt] = to_insert;
+    to_insert->prev = prev;
+    to_insert->next = next;
+    if (prev != nullptr) {
+      prev->next = to_insert;
+    } else {
+      this->head = to_insert;
+    }
+    if (next != nullptr) {
+      next->prev = to_insert;
+    }
+    // Step 2. For each variable produced by the node
+    // 1) check if it doesn't have a producer yet
+    // 2) record its producer as this node
+    for (const Any &var : to_insert->output_vars) {
+      if (auto it = this->var_to_producer.find(var); it != this->var_to_producer.end()) {
+        MLC_THROW(RuntimeError) << "Variable already has a producer by another node: "
+                                << it->second.operator DepNode()->stmt;
+      } else {
+        this->var_to_producer[var] = to_insert;
+        this->var_to_consumers[var] = UList{};
+      }
+    }
+    // Step 3. For each variable consumed by the node
+    // 1) check if the var is in the graph
+    // 1) add a new consumer of this var
+    for (const Any &var : to_insert->input_vars) {
+      if (!this->var_to_producer.count(var)) {
+        MLC_THROW(RuntimeError) << "Variable is not produced by any node in the graph: " << var;
+      }
+      this->var_to_consumers.at(var).operator UListObj *()->push_back(to_insert);
+    }
+  }
+};
+
+struct DepGraph : public ObjectRef {
+  MLC_DEF_OBJ_REF(MLC_EXPORTS, DepGraph, DepGraphObj, ObjectRef)
+      .Field("_stmt_to_inputs", &DepGraphObj::stmt_to_inputs, /*frozen=*/true)
+      .Field("_stmt_to_outputs", &DepGraphObj::stmt_to_outputs, /*frozen=*/true)
+      .Field("_stmt_to_node", &DepGraphObj::stmt_to_node, /*frozen=*/true)
+      .Field("_var_to_producer", &DepGraphObj::var_to_producer, /*frozen=*/true)
+      .Field("_var_to_consumers", &DepGraphObj::var_to_consumers, /*frozen=*/true)
+      .Field("_head", &DepGraphObj::head, /*frozen=*/true)
+      .StaticFn("__init__", InitOf<DepGraphObj, Func, Func, UDict, UDict, UDict, DepNode>)
+      .StaticFn("_init_from_stmts", InitOf<DepGraphObj, UList, UList, Func, Func>)
+      .MemFn("clear", &DepGraphObj::Clear)
+      .MemFn("create_node", &DepGraphObj::CreateNode)
+      .MemFn("get_node_from_stmt", &DepGraphObj::GetNodeFromStmt)
+      .MemFn("insert_before", &DepGraphObj::InsertBefore)
+      .MemFn("insert_after", &DepGraphObj::InsertAfter)
+      .MemFn("erase_node", &DepGraphObj::EraseNode)
+      .MemFn("replace", &DepGraphObj::Replace)
+      .MemFn("get_node_producers", &DepGraphObj::GetNodeProducers)
+      .MemFn("get_node_consumers", &DepGraphObj::GetNodeConsumers)
+      .MemFn("get_var_producer", &DepGraphObj::GetVarProducer)
+      .MemFn("get_var_consumers", &DepGraphObj::GetVarConsumers);
+
+  explicit DepGraph(Func stmt_to_inputs, Func stmt_to_outputs, UDict stmt_to_node, UDict var_to_producer,
+                    UDict var_to_consumers, DepNode head)
+      : DepGraph(
+            DepGraph::New(stmt_to_inputs, stmt_to_outputs, stmt_to_node, var_to_producer, var_to_consumers, head)) {}
+
+  explicit DepGraph(UList input_vars, UList stmts, Func stmt_to_inputs, Func stmt_to_outputs)
+      : DepGraph(DepGraph::New(input_vars, stmts, stmt_to_inputs, stmt_to_outputs)) {}
+};
+
+} // namespace core
+} // namespace mlc
+
+#endif // MLC_CORE_DEP_GRAPH_H_

--- a/python/mlc/__init__.py
+++ b/python/mlc/__init__.py
@@ -12,9 +12,11 @@ from .core import (
     Opaque,
     Tensor,
     build_info,
+    dep_graph,
     json_loads,
     typing,
 )
+from .core.dep_graph import DepGraph, DepNode
 from .dataclasses import PyClass, c_class, py_class
 
 try:

--- a/python/mlc/core/dep_graph.py
+++ b/python/mlc/core/dep_graph.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from typing import Any
+
+from mlc.core import Func, Object
+from mlc.dataclasses import c_class
+
+Stmt = Any
+Var = Any
+
+
+@c_class("mlc.core.DepNode")
+class DepNode(Object):
+    stmt: Stmt
+    input_vars: list[Var]
+    output_vars: list[Var]
+    _prev: Object
+    _next: Object
+
+    @property
+    def prev(self) -> DepNode | None:
+        return self._prev
+
+    @property
+    def next(self) -> DepNode | None:
+        return self._next
+
+
+@c_class("mlc.core.DepGraph", init=False)
+class DepGraph(Object):
+    _stmt_to_inputs: Func
+    _stmt_to_outputs: Func
+    _stmt_to_node: dict
+    _var_to_producer: dict
+    _var_to_consumers: dict
+    _head: DepNode
+
+    @staticmethod
+    def from_stmts(
+        input_vars: list[Var],
+        stmts: list[Stmt],
+        stmt_to_inputs: Callable[[Stmt], list[Var]],
+        stmt_to_outputs: Callable[[Stmt], list[Var]],
+    ) -> DepGraph:
+        return DepGraph._C(
+            b"_init_from_stmts",
+            input_vars,
+            stmts,
+            stmt_to_inputs,
+            stmt_to_outputs,
+        )
+
+    def clear(self) -> None:
+        DepGraph._C(b"clear", self)
+
+    def create_node(self, stmt: Stmt) -> DepNode:
+        return DepGraph._C(b"create_node", self, stmt)
+
+    def get_node_from_stmt(self, stmt: Stmt) -> DepNode:
+        return DepGraph._C(b"get_node_from_stmt", self, stmt)
+
+    def insert_before(self, anchor: DepNode, node: DepNode) -> None:
+        DepGraph._C(b"insert_before", self, anchor, node)
+
+    def insert_after(self, anchor: DepNode, node: DepNode) -> None:
+        DepGraph._C(b"insert_after", self, anchor, node)
+
+    def erase_node(self, to_erase: DepNode) -> None:
+        DepGraph._C(b"erase_node", self, to_erase)
+
+    def replace(self, old_node: DepNode, new_node: DepNode) -> None:
+        DepGraph._C(b"replace", self, old_node, new_node)
+
+    def get_node_producers(self, node: DepNode) -> list[DepNode]:
+        return DepGraph._C(b"get_node_producers", self, node)
+
+    def get_node_consumers(self, node: DepNode) -> list[DepNode]:
+        return DepGraph._C(b"get_node_consumers", self, node)
+
+    def get_var_producer(self, v: Var) -> DepNode:
+        return DepGraph._C(b"get_var_producer", self, v)
+
+    def get_var_consumers(self, v: Var) -> list[DepNode]:
+        return DepGraph._C(b"get_var_consumers", self, v)
+
+    @property
+    def nodes(self) -> Generator[DepNode, None, None]:
+        node: DepNode | None = self._head
+        while node is not None:
+            yield node
+            node = node.next

--- a/tests/python/test_core_dep_graph.py
+++ b/tests/python/test_core_dep_graph.py
@@ -1,0 +1,686 @@
+import mlc.dataclasses as mlcd
+import pytest
+from mlc import DepGraph
+
+
+@mlcd.py_class(repr=False)
+class Var(mlcd.PyClass):
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@mlcd.py_class(repr=False)
+class Stmt(mlcd.PyClass):
+    args: list[Var]
+    outs: list[Var]
+
+    def __str__(self) -> str:
+        lhs = ", ".join(x.name for x in self.outs) if self.outs else "(empty)"
+        rhs = ", ".join(x.name for x in self.args) if self.args else "(empty)"
+        return f"{lhs} := {rhs}"
+
+
+def stmt_inputs(stmt: Stmt) -> list[Var]:
+    return stmt.args
+
+
+def stmt_outputs(stmt: Stmt) -> list[Var]:
+    return stmt.outs
+
+
+# --- Fixtures ---
+@pytest.fixture
+def simple_graph() -> tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]]:
+    # a -> b -> c -> d
+    a, b, c, d = Var("a"), Var("b"), Var("c"), Var("d")
+    stmts = [Stmt(args=[a], outs=[b]), Stmt(args=[b], outs=[c]), Stmt(args=[c], outs=[d])]
+    g = DepGraph.from_stmts(
+        input_vars=[a],
+        stmts=stmts,
+        stmt_to_inputs=stmt_inputs,
+        stmt_to_outputs=stmt_outputs,
+    )
+    return g, (a, b, c, d), stmts
+
+
+@pytest.fixture
+def branch_graph() -> tuple[DepGraph, tuple[Var, Var, Var, Var, Var], list[Stmt]]:
+    a = Var("a")
+    b = Var("b")
+    c = Var("c")
+    d = Var("d")
+    e = Var("e")
+    stmts = [Stmt(args=[a], outs=[b, c]), Stmt(args=[b], outs=[d]), Stmt(args=[c], outs=[e])]
+    g = DepGraph.from_stmts([a], stmts, stmt_inputs, stmt_outputs)
+    return g, (a, b, c, d, e), stmts
+
+
+# --- Tests covering all APIs ---
+
+
+def test_from_stmts_nodes_and_var_mappings(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    # Check nodes iteration: head + 3 stmt nodes
+    nodes = list(g.nodes)
+    assert len(nodes) == 4
+    head, n1, n2, n3 = nodes
+    assert head.stmt is None
+    assert g.get_var_producer(a).is_(head)
+    assert g.get_var_consumers(a) == [n1]
+    assert g.get_var_producer(b).is_(n1)
+    assert g.get_var_consumers(b) == [n2]
+    assert g.get_var_producer(d).is_(n3)
+    # heads next/prev
+    assert head.next.is_(n1) and n1.prev.is_(head)  # type: ignore[union-attr]
+    # get_node_from_stmt valid and invalid
+    assert g.get_node_from_stmt(stmts[0]).is_(n1)
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(Stmt(args=[], outs=[]))
+
+
+def test_create_and_insert(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, _, _, _), _ = simple_graph
+    # create a new statement e := a
+    e = Var("e")
+    new_stmt = Stmt(args=[a], outs=[e])
+    new_node = g.create_node(new_stmt)
+    # not yet in graph: get_node_from_stmt should fail
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(new_stmt)
+    # insert after head
+    g.insert_after(g._head, new_node)
+    # now in graph
+    assert g.get_node_from_stmt(new_stmt).is_(new_node)
+    # var mapping updated
+    assert g.get_var_producer(e).is_(new_node)
+    assert new_node in g.get_var_consumers(a)
+    # remove the inserted node for cleanup
+    g.erase_node(new_node)
+
+
+def test_insert_before_and_order(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (_, b, _, _), _ = simple_graph
+    nodes = list(g.nodes)
+    _, n1, n2, _ = nodes
+    x = Var("x")
+    x_stmt = Stmt(args=[b], outs=[x])
+    x_node = g.create_node(x_stmt)
+    g.insert_before(n2, x_node)
+    assert x_node.prev.is_(n1) and x_node.next.is_(n2)  # type: ignore[union-attr]
+    assert n1.next.is_(x_node) and n2.prev.is_(x_node)  # type: ignore[union-attr]
+    g.erase_node(x_node)
+
+
+def test_erase_node_and_cleanup(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (_, _, _, d), _ = simple_graph
+    nodes = list(g.nodes)
+    _, _, _, n3 = nodes
+    # safe to erase leaf n3 (d := c)
+    g.erase_node(n3)
+    # n3 removed from iteration
+    remaining = list(g.nodes)
+    assert n3 not in remaining
+    # var d should be gone
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(d)
+    with pytest.raises(RuntimeError):
+        g.get_var_consumers(d)
+
+
+def test_replace_updates_links_and_vars(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (_, b, c, _), _ = simple_graph
+    nodes = list(g.nodes)
+    _, n1, n2, n3 = nodes
+    # replace middle node n2 (c := b) with new node C2: e := b
+    e = Var("e")
+    c2_stmt = Stmt(args=[b], outs=[e])
+    c2_node = g.create_node(c2_stmt)
+    g.replace(n2, c2_node)
+    # new_node in graph
+    assert g.get_var_producer(e).is_(c2_node)
+    # old var c removed
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(c)
+    # consumer of b updated: find c2_node and original n3 now consumes e
+    assert c2_node in g.get_var_consumers(b)
+    # link continuity: n1->c2_node->n3
+    assert c2_node.prev.is_(n1) and c2_node.next.is_(n3)  # type: ignore[union-attr]
+
+
+def test_clear_resets_graph(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    g.clear()
+    # only head remains, with no links
+    nodes = list(g.nodes)
+    assert len(nodes) == 1
+    head = nodes[0]
+    assert head.prev is None and head.next is None
+    # mappings empty
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(a)
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(stmts[0])
+
+
+def test_simple_graph_structure(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    nodes = list(g.nodes)
+    assert len(nodes) == 4
+    head, n1, n2, n3 = nodes
+    assert head.stmt is None
+    assert head.prev is None
+    assert n3.next is None
+
+
+def test_simple_graph_mappings(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    head, n1, n2, n3 = list(g.nodes)
+    assert g.get_var_producer(a).is_(head)
+    assert g.get_var_consumers(a) == [n1]
+    assert g.get_var_producer(b).is_(n1)
+    assert g.get_var_consumers(b) == [n2]
+    assert g.get_var_producer(d).is_(n3)
+
+
+def test_nodes_iteration(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    seq1 = [node for node in g.nodes]
+    seq2 = []
+    it = g.nodes
+    for node in it:
+        seq2.append(node)
+    assert seq1 == seq2
+
+
+def test_get_node_from_stmt_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(Stmt(args=[], outs=[]))
+
+
+def test_create_and_insert_2(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    e = Var("e")
+    new_stmt = Stmt(args=[a], outs=[e])
+    new_node = g.create_node(new_stmt)
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(new_stmt)
+    g.insert_after(g._head, new_node)
+    assert g.get_node_from_stmt(new_stmt).is_(new_node)
+    assert g.get_var_producer(e).is_(new_node)
+    assert new_node in g.get_var_consumers(a)
+    g.erase_node(new_node)
+
+
+def test_insert_after_tail(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    tail = list(g.nodes)[-1]
+    x = Var("x")
+    x_stmt = Stmt(args=[d], outs=[x])
+    x_node = g.create_node(x_stmt)
+    g.insert_after(tail, x_node)
+    assert tail.next.is_(x_node)  # type: ignore[union-attr]
+    assert x_node.prev.is_(tail)  # type: ignore[union-attr]
+    assert x_node.next is None
+    g.erase_node(x_node)
+
+
+def test_insert_before_head_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    x = Var("x")
+    x_node = g.create_node(Stmt(args=[a], outs=[x]))
+    with pytest.raises(RuntimeError):
+        g.insert_before(g._head, x_node)
+
+
+def test_insert_invalid_anchor_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    orphan = g.create_node(Stmt(args=[], outs=[]))
+    y = Var("y")
+    y_node = g.create_node(Stmt(args=[b], outs=[y]))
+    with pytest.raises(RuntimeError):
+        g.insert_after(orphan, y_node)
+
+
+def test_insert_node_already_in_graph_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    e = Var("e")
+    stmt_e = Stmt(args=[a], outs=[e])
+    node_e = g.create_node(stmt_e)
+    g.insert_after(g._head, node_e)
+    with pytest.raises(RuntimeError):
+        g.insert_after(g._head, node_e)
+    g.erase_node(node_e)
+
+
+def test_insert_duplicate_stmt_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    stmt = stmts[0]
+    dup = g.create_node(stmt)
+    with pytest.raises(RuntimeError):
+        g.insert_after(g._head, dup)
+
+
+def test_insert_duplicate_var_producer_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    new_stmt = Stmt(args=[a], outs=[b])
+    dup = g.create_node(new_stmt)
+    with pytest.raises(RuntimeError):
+        g.insert_after(g._head, dup)
+
+
+def test_erase_leaf(simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]]) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    g.erase_node(n3)
+    assert n3 not in list(g.nodes)
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(d)
+    with pytest.raises(RuntimeError):
+        g.get_var_consumers(d)
+
+
+def test_erase_head_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.erase_node(g._head)
+
+
+def test_erase_not_in_graph_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    orphan = g.create_node(Stmt(args=[a], outs=[Var("x")]))
+    with pytest.raises(RuntimeError):
+        g.erase_node(orphan)
+
+
+def test_erase_with_consumers_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.erase_node(g.get_node_from_stmt(stmts[0]))
+
+
+def test_replace_middle(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    e = Var("e")
+    new = Stmt(args=[b], outs=[e])
+    new_node = g.create_node(new)
+    g.replace(n2, new_node)
+    assert g.get_var_producer(e).is_(new_node)
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(c)
+    assert new_node.prev.is_(n1)  # type: ignore[union-attr]
+    assert new_node.next.is_(n3)  # type: ignore[union-attr]
+
+
+def test_replace_tail(simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]]) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    f = Var("f")
+    new = Stmt(args=[c], outs=[f])
+    new_node = g.create_node(new)
+    g.replace(n3, new_node)
+    assert g.get_var_producer(f).is_(new_node)
+    assert new_node.next is None
+    assert n2.next.is_(new_node)  # type: ignore[union-attr]
+
+
+def test_replace_noop(simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]]) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    g.replace(n2, n2)
+    assert g.get_node_from_stmt(stmts[1]).is_(n2)
+
+
+def test_replace_head_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.replace(g._head, g.create_node(Stmt(args=[a], outs=[Var("x")])))
+
+
+def test_replace_old_not_in_graph_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    orphan = g.create_node(Stmt(args=[a], outs=[Var("x")]))
+    new = g.create_node(Stmt(args=[a], outs=[Var("y")]))
+    with pytest.raises(RuntimeError):
+        g.replace(orphan, new)
+
+
+def test_replace_new_in_graph_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    new = Stmt(args=[b], outs=[Var("e")])
+    n_new = g.create_node(new)
+    g.insert_after(n1, n_new)
+    with pytest.raises(RuntimeError):
+        g.replace(n3, n_new)
+    g.erase_node(n_new)
+
+
+def test_replace_mismatched_output_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    new = Stmt(args=[b], outs=[Var("x"), Var("y")])
+    new_node = g.create_node(new)
+    with pytest.raises(RuntimeError):
+        g.replace(n2, new_node)
+
+
+def test_get_node_producers_success(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    assert g.get_node_producers(n2) == [n1]
+
+
+def test_get_node_consumers_success(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    assert g.get_node_consumers(n1) == [n2]
+
+
+def test_get_node_consumers_error_not_in_graph(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    orphan = g.create_node(Stmt(args=[a], outs=[Var("x")]))
+    with pytest.raises(RuntimeError):
+        g.get_node_consumers(orphan)
+
+
+def test_get_var_producer_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(Var("z"))
+
+
+def test_get_var_consumers_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    with pytest.raises(RuntimeError):
+        g.get_var_consumers(Var("z"))
+
+
+def test_clear(simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]]) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    g.clear()
+    nodes = list(g.nodes)
+    assert len(nodes) == 1
+    head = nodes[0]
+    assert head.prev is None and head.next is None
+    with pytest.raises(RuntimeError):
+        g.get_var_producer(a)
+    with pytest.raises(RuntimeError):
+        g.get_node_from_stmt(stmts[0])
+
+
+def test_branch_graph_structure(
+    branch_graph: tuple[DepGraph, tuple[Var, Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d, e), stmts = branch_graph
+    nodes = list(g.nodes)
+    assert len(nodes) == 4
+
+
+def test_branch_graph_mappings(
+    branch_graph: tuple[DepGraph, tuple[Var, Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d, e), stmts = branch_graph
+    _, n1, n2, n3 = list(g.nodes)
+    assert g.get_var_producer(b).is_(n1)
+    assert g.get_var_producer(c).is_(n1)
+    assert g.get_var_consumers(b) == [n2]
+    assert g.get_var_consumers(c) == [n3]
+
+
+def test_duplicate_producer_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    dup_stmt = Stmt(args=[b], outs=[c])
+    dup_node = g.create_node(dup_stmt)
+    with pytest.raises(RuntimeError):
+        g.insert_after(g.get_node_from_stmt(stmts[1]), dup_node)
+
+
+def test_duplicate_stmt_error(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    dup = g.create_node(stmts[1])
+    with pytest.raises(RuntimeError):
+        g.insert_after(g.get_node_from_stmt(stmts[0]), dup)
+
+
+def test_identity_equality(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    a2 = Var("a")
+    new = Stmt(args=[a2], outs=[Var("x")])
+    node = g.create_node(new)
+    with pytest.raises(RuntimeError):
+        g.insert_after(g._head, node)
+
+
+def test_empty_graph() -> None:
+    g = DepGraph.from_stmts([], [], stmt_inputs, stmt_outputs)
+    nodes = list(g.nodes)
+    assert len(nodes) == 1
+    head = nodes[0]
+    assert head.prev is None and head.next is None
+
+
+def test_graph_only_inputs() -> None:
+    a = Var("a")
+    b = Var("b")
+    g = DepGraph.from_stmts([a, b], [], stmt_inputs, stmt_outputs)
+    nodes = list(g.nodes)
+    assert len(nodes) == 1
+    head = nodes[0]
+    assert g.get_var_producer(a).is_(head)
+    assert g.get_var_producer(b).is_(head)
+
+
+def test_no_io_stmts() -> None:
+    a = Var("a")
+    stmts = [Stmt(args=[], outs=[]), Stmt(args=[], outs=[])]
+    g = DepGraph.from_stmts([a], stmts, stmt_inputs, stmt_outputs)
+    nodes = list(g.nodes)
+    assert len(nodes) == 3
+
+
+def test_long_chain() -> None:
+    vars = [Var(str(i)) for i in range(10)]
+    stmts = [Stmt(args=[vars[i]], outs=[vars[i + 1]]) for i in range(9)]
+    g = DepGraph.from_stmts([vars[0]], stmts, stmt_inputs, stmt_outputs)
+    assert len(list(g.nodes)) == 10
+
+
+def test_multiple_consumers_for_single_var(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    x1 = Stmt(args=[a], outs=[Var("x")])
+    x2 = Stmt(args=[a], outs=[Var("y")])
+    n1 = g.create_node(x1)
+    n2 = g.create_node(x2)
+    g.insert_after(g._head, n1)
+    g.insert_after(g._head, n2)
+    consumers = g.get_var_consumers(a)
+    assert n1 in consumers and n2 in consumers
+
+
+def test_wrapper_prev_none(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    head = next(iter(g.nodes))
+    assert head.prev is None
+
+
+def test_wrapper_next_none(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    tail = list(g.nodes)[-1]
+    assert tail.next is None
+
+
+def test_wrapper_prev_next_valid(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    head, n1, _, _ = list(g.nodes)
+    assert n1.prev.is_(head) and head.next.is_(n1)  # type: ignore[union-attr]
+
+
+def test_graph_iter_stop_iteration(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    it = g.nodes
+    for _ in range(len(list(g.nodes))):
+        next(it)
+    with pytest.raises(StopIteration):
+        next(it)
+
+
+def test_clear_idempotent(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    g.clear()
+    g.clear()
+    assert len(list(g.nodes)) == 1
+
+
+def test_replace_sequence(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    u = Var("u")
+    v = Var("v")
+    g, (a, b, c, d), stmts = simple_graph
+    _, n1, n2, n3 = list(g.nodes)
+    n2b = g.create_node(Stmt(args=[b], outs=[u]))
+    n3b = g.create_node(Stmt(args=[u], outs=[v]))
+    g.replace(n2, n2b)
+    g.replace(n3, n3b)
+    assert g.get_var_producer(u).is_(n2b)
+    assert g.get_var_producer(v).is_(n3b)
+
+
+def test_multiple_inserts_order(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    n4 = g.create_node(Stmt(args=[a], outs=[Var("p")]))
+    n5 = g.create_node(Stmt(args=[a], outs=[Var("q")]))
+    g.insert_after(g._head, n4)
+    g.insert_after(g._head, n5)
+    seq = list(g.nodes)
+    assert seq[1].is_(n5) and seq[2].is_(n4)
+
+
+def test_multiple_inserts_before_tail(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    tail = list(g.nodes)[-1]
+    n1 = g.create_node(Stmt(args=[c], outs=[Var("m")]))
+    n2 = g.create_node(Stmt(args=[c], outs=[Var("n")]))
+    g.insert_before(tail, n2)
+    g.insert_before(tail, n1)
+    seq = list(g.nodes)
+    idx = seq.index(tail)
+    assert seq[idx - 1].is_(n1) and seq[idx - 2].is_(n2)
+
+
+def test_stmt_to_node_mapping_direct(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    n1 = g.get_node_from_stmt(stmts[0])
+    assert g._stmt_to_node[stmts[0]].is_(n1)
+
+
+def test_var_to_producer_direct(
+    simple_graph: tuple[DepGraph, tuple[Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d), stmts = simple_graph
+    head = g._head
+    assert g._var_to_producer[a].is_(head)
+
+
+def test_branch_graph_nodes_iteration(
+    branch_graph: tuple[DepGraph, tuple[Var, Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d, e), stmts = branch_graph
+    seq = list(g.nodes)
+    assert len(seq) == 4
+
+
+def test_graph_clear_branch_graph(
+    branch_graph: tuple[DepGraph, tuple[Var, Var, Var, Var, Var], list[Stmt]],
+) -> None:
+    g, (a, b, c, d, e), stmts = branch_graph
+    g.clear()
+    assert len(list(g.nodes)) == 1


### PR DESCRIPTION
Here’s a draft GitHub PR description you can drop into your merge request:

This PR introduces a `torch.fx.Graph` style **doubly‐linked** dependency graph
- Nodes wrap an opaque "statement" plus its input/output variables  
- Maintains:
    - a `stmt_to_node` map to find a node by its statement  
    - a `var_to_producer` map from each variable to the node that produces it  
    - a `var_to_consumers` map from each variable to all nodes that consume it  
- Provides safe, consistent APIs to:
    - create, insert (before/after), replace, erase nodes
    - query producers/consumers by node or by variable  

### Why it matters
- Enables IR-level transformations and analyses that need to track data dependencies  
- Guarantees correctness of producer/consumer relationships as the graph is edited  
- Lays the groundwork for scheduling passes (topological sort, liveness, CSE, fusion, etc.)

### Unittests
50 pytest cases covering:
- basic chain graphs, branching graphs, empty/inputs‐only graphs  
- all API calls, success & failure modes (invalid anchors, duplicate stmts/vars, head/leaf errors)  
- identity vs. equality, iteration‐stop, idempotent clears, and more  
