### PR TITLE
feat(cython): Hide C++ stacktrace by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_REQUIRES: "pytest torch"
   CIBW_TEST_COMMAND: "pytest -svv --durations=20 {project}/tests/python/"
+  CIBW_ENVIRONMENT: "MLC_SHOW_CPP_STACKTRACES=1"
   MLC_CIBW_VERSION: "2.22.0"
   MLC_PYTHON_VERSION: "3.9"
   MLC_CIBW_WIN_BUILD: "cp39-win_amd64"

--- a/python/mlc/_cython/__init__.py
+++ b/python/mlc/_cython/__init__.py
@@ -27,6 +27,7 @@ from .base import (
 )
 from .core import (  # type: ignore[import-not-found]
     container_to_py,
+    cxx_stacktrace_enabled,
     device_as_pair,
     dtype_as_triple,
     dtype_from_triple,
@@ -50,6 +51,7 @@ from .core import (  # type: ignore[import-not-found]
     tensor_shape,
     tensor_strides,
     tensor_to_dlpack,
+    toggle_cxx_stacktrace,
     type_add_method,
     type_cast,
     type_create,

--- a/python/mlc/core/func.py
+++ b/python/mlc/core/func.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-from mlc._cython import c_class_core, func_call, func_get, func_init, func_register
+from mlc._cython import (
+    c_class_core,
+    cxx_stacktrace_enabled,
+    func_call,
+    func_get,
+    func_init,
+    func_register,
+)
 
 from .object import Object
 
@@ -17,7 +24,13 @@ class Func(Object):
         func_init(self, func)
 
     def __call__(self, *args: Any) -> Any:
-        return func_call(self, args)
+        if cxx_stacktrace_enabled():
+            return func_call(self, args)
+        else:
+            try:
+                return func_call(self, args)
+            except Exception as e:
+                raise e.with_traceback(None)
 
     @staticmethod
     def get(name: str, allow_missing: bool = False) -> Func:


### PR DESCRIPTION
This PR introduces an environment variable `MLC_SHOW_CPP_STACKTRACES`, which controls if CXX-side stacktrace is included when an exception is thrown. It's turned on only if it's value is `1`. It means C++ stacktrace is hidden by default.

Should fix #68.

