### PR TITLE
feat(core): Support serialization of opaque objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 env:
   CIBW_BUILD_VERBOSITY: 3
-  CIBW_TEST_REQUIRES: "pytest torch"
+  CIBW_TEST_REQUIRES: "pytest torch jsonpickle"
   CIBW_TEST_COMMAND: "pytest -svv --durations=20 {project}/tests/python/"
   CIBW_ENVIRONMENT: "MLC_SHOW_CPP_STACKTRACES=1"
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: "v1.14.1"
     hooks:
       - id: mypy
-        additional_dependencies: ['numpy >= 1.22', "ml-dtypes >= 0.1", "pytest", "torch"]
+        additional_dependencies: ['numpy >= 1.22', "ml-dtypes >= 0.1", "pytest", "torch", "jsonpickle"]
         args: [--show-error-codes]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: "v19.1.6"

--- a/cpp/registry.h
+++ b/cpp/registry.h
@@ -19,8 +19,8 @@ namespace mlc {
 namespace registry {
 
 Any JSONLoads(AnyView json_str);
-Any JSONDeserialize(AnyView json_str);
-Str JSONSerialize(AnyView source);
+Any JSONDeserialize(AnyView json_str, FuncObj *fn_opaque_deserialize);
+Str JSONSerialize(AnyView source, FuncObj *fn_opaque_serialize);
 bool StructuralEqual(AnyView lhs, AnyView rhs, bool bind_free_vars, bool assert_mode);
 int64_t StructuralHash(AnyView root);
 Optional<Str> StructuralEqualFailReason(AnyView lhs, AnyView rhs, bool bind_free_vars);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors = [{ name = "MLC Authors", email = "junrushao@apache.org" }]
 "mlc.config" = "mlc.config:main"
 
 [project.optional-dependencies]
-tests = ['pytest', 'torch']
+tests = ['pytest', 'torch', 'jsonpickle']
 dev = [
     "cython>=3.1",
     "pre-commit",
@@ -35,6 +35,7 @@ dev = [
     "ruff",
     "mypy",
     "torch",
+    "jsonpickle",
 ]
 
 [build-system]

--- a/python/mlc/_cython/core.pyx
+++ b/python/mlc/_cython/core.pyx
@@ -360,16 +360,16 @@ cdef class PyAny:
         return (base.new_object, (type(self),), self.__getstate__())
 
     def __getstate__(self):
-        return {"mlc_json": func_call(_SERIALIZE, (self,))}
+        return {"mlc_json": func_call(_SERIALIZE, (self, None))}
 
     def __setstate__(self, state):
-        cdef PyAny ret = func_call(_DESERIALIZE, (state["mlc_json"], ))
+        cdef PyAny ret = func_call(_DESERIALIZE, (state["mlc_json"], None))
         cdef MLCAny tmp = self._mlc_any
         self._mlc_any = ret._mlc_any
         ret._mlc_any = tmp
 
-    def _mlc_json(self):
-        return func_call(_SERIALIZE, (self,))
+    def _mlc_json(self, fn_opaque_serialize):
+        return func_call(_SERIALIZE, (self, fn_opaque_serialize))
 
     def _mlc_swap(self, PyAny other):
         cdef MLCAny tmp = self._mlc_any
@@ -377,8 +377,8 @@ cdef class PyAny:
         other._mlc_any = tmp
 
     @staticmethod
-    def _mlc_from_json(mlc_json):
-        return func_call(_DESERIALIZE, (mlc_json,))
+    def _mlc_from_json(mlc_json, fn_opaque_deserialize):
+        return func_call(_DESERIALIZE, (mlc_json, fn_opaque_deserialize))
 
     @staticmethod
     def _mlc_eq_s(PyAny lhs, PyAny rhs, bint bind_free_vars, bint assert_mode) -> bool:
@@ -1442,8 +1442,8 @@ cpdef void func_init(PyAny self, object callable):
     self._mlc_any = ret._mlc_any
     ret._mlc_any = _MLCAnyNone()
 
-cpdef void opaque_init(PyAny self, object callable):
-    cdef PyAny ret = _pyany_from_opaque(callable)
+cpdef void opaque_init(PyAny self, object opaque):
+    cdef PyAny ret = _pyany_from_opaque(opaque)
     self._mlc_any = ret._mlc_any
     ret._mlc_any = _MLCAnyNone()
 

--- a/python/mlc/core/object.py
+++ b/python/mlc/core/object.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Callable
 
 from mlc._cython import PyAny, TypeInfo, c_class_core
 
@@ -20,12 +21,18 @@ class Object(PyAny):
     def is_(self, other: Object) -> bool:
         return isinstance(other, Object) and self._mlc_address == other._mlc_address
 
-    def json(self) -> str:
-        return super()._mlc_json()
+    def json(
+        self,
+        fn_opaque_serialize: Callable[[list[typing.Any]], str] | None = None,
+    ) -> str:
+        return super()._mlc_json(fn_opaque_serialize)
 
     @staticmethod
-    def from_json(json_str: str) -> Object:
-        return PyAny._mlc_from_json(json_str)  # type: ignore[attr-defined]
+    def from_json(
+        json_str: str,
+        fn_opaque_deserialize: Callable[[str], list[typing.Any]] | None = None,
+    ) -> Object:
+        return PyAny._mlc_from_json(json_str, fn_opaque_deserialize)  # type: ignore[attr-defined]
 
     def eq_s(
         self,

--- a/python/mlc/core/opaque.py
+++ b/python/mlc/core/opaque.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
-from mlc._cython import Ptr, c_class_core, opaque_init, register_opauqe_type
+from mlc._cython import Ptr, c_class_core, func_register, opaque_init, register_opauqe_type
 
 from .object import Object
 
@@ -15,5 +16,32 @@ class Opaque(Object):
         opaque_init(self, instance)
 
     @staticmethod
-    def register(ty: type) -> None:
+    def register(
+        ty: type,
+        eq_s: Callable | None = None,
+        hash_s: Callable | None = None,
+    ) -> None:
         register_opauqe_type(ty)
+        name = ty.__module__ + "." + ty.__name__
+        if eq_s is not None:
+            assert callable(eq_s)
+            func_register(f"Opaque.eq_s.{name}", False, eq_s)
+        if hash_s is not None:
+            assert callable(hash_s)
+            func_register(f"Opaque.hash_s.{name}", False, hash_s)
+
+
+def _default_serialize(opaques: list[Any]) -> str:
+    import jsonpickle  # type: ignore[import-untyped]
+
+    return jsonpickle.dumps(list(opaques))
+
+
+def _default_deserialize(json_str: str) -> list[Any]:
+    import jsonpickle  # type: ignore[import-untyped]
+
+    return jsonpickle.loads(json_str)
+
+
+func_register("mlc.Opaque.default.serialize", False, _default_serialize)
+func_register("mlc.Opaque.default.deserialize", False, _default_deserialize)

--- a/tests/python/test_dataclasses_serialize.py
+++ b/tests/python/test_dataclasses_serialize.py
@@ -1,16 +1,22 @@
 import json
 import pickle
-from typing import Optional
+from typing import Any, Optional
 
 import mlc
 
 
-@mlc.dataclasses.py_class("mlc.testing.serialize")
+@mlc.dataclasses.py_class("mlc.testing.serialize", init=False)
 class ObjTest(mlc.PyClass):
     a: int
     b: float
     c: str
     d: bool
+
+    def __init__(self, b: float, c: str, a: int, d: bool) -> None:
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
 
 
 @mlc.dataclasses.py_class("mlc.testing.serialize_opt")
@@ -21,8 +27,13 @@ class ObjTestOpt(mlc.PyClass):
     d: Optional[bool]
 
 
+@mlc.dataclasses.py_class("mlc.testing.AnyContainer")
+class AnyContainer(mlc.PyClass):
+    field: Any
+
+
 def test_json() -> None:
-    obj = ObjTest(1, 2.0, "3", True)
+    obj = ObjTest(a=1, b=2.0, c="3", d=True)
     obj_json = obj.json()
     obj_json_dict = json.loads(obj_json)
     assert obj_json_dict["type_keys"] == ["mlc.testing.serialize", "int"]
@@ -35,7 +46,7 @@ def test_json() -> None:
 
 
 def test_pickle() -> None:
-    obj = ObjTest(1, 2.0, "3", False)
+    obj = ObjTest(a=1, b=2.0, c="3", d=True)
     obj_pickle = pickle.dumps(obj)
     obj_from_pickle = pickle.loads(obj_pickle)
     assert obj.a == obj_from_pickle.a
@@ -49,7 +60,24 @@ def test_json_opt_0() -> None:
     obj_json = obj.json()
     obj_json_dict = json.loads(obj_json)
     assert obj_json_dict["type_keys"] == ["mlc.testing.serialize_opt", "int"]
-    assert obj_json_dict["values"] == ["3", [0, [1, 1], 2.0, 0, True]]
+    assert obj_json_dict["values"] == [
+        "3",  # values[0] = literal: "3"
+        [
+            # values[1].type_index = 0 ===> ObjTestOpt
+            0,
+            # values[1].0
+            [
+                1,  # type_index = 1 ===> int
+                1,  # value = 1
+            ],
+            # values[1].1 = literal: 2.0
+            2.0,
+            # values[1].2 = values[0]
+            0,
+            # values[1].3 = literal: True
+            True,
+        ],
+    ]
     obj_from_json: ObjTestOpt = ObjTestOpt.from_json(obj_json)
     assert obj.a == obj_from_json.a
     assert obj.b == obj_from_json.b
@@ -68,3 +96,20 @@ def test_json_opt_1() -> None:
     assert obj.b == obj_from_json.b
     assert obj.c == obj_from_json.c
     assert obj.d == obj_from_json.d
+
+
+def test_json_dag() -> None:
+    lst = mlc.List([1, 2.0, "3", True])
+    dct = mlc.Dict({"a": 1, "b": 2.0, "c": "3", "d": True, "v": lst})
+    big_lst = mlc.List([lst, dct, lst, dct])
+    obj_1 = AnyContainer([big_lst, big_lst])
+    obj_2: AnyContainer = AnyContainer.from_json(obj_1.json())
+    assert obj_2.field[0].is_(obj_2.field[1])
+    assert obj_2.field[0] == big_lst
+    big_lst = obj_2.field[0]
+    assert big_lst[0].is_(big_lst[2])  # type: ignore[attr-defined]
+    assert big_lst[1].is_(big_lst[3])  # type: ignore[attr-defined]
+    assert big_lst[0] == lst
+    assert big_lst[1] == dct
+    lst, dct = big_lst[:2]  # type: ignore[assignment]
+    assert dct["v"].is_(lst)  # type: ignore[attr-defined]


### PR DESCRIPTION
Serialization/deserialization support for `mlc.Opaque`. Part of #73.

For any MLC object, it now supports:
- `.json(...)` method adds argument `fn_opaque_serialize`, which allows users to supply a customized serialization function;
- `.from_json(...)` adds argument `fn_opaque_deserialize`, which allows users to supply a customized deserialization function.

By default, the serialization and deserialization methods are:

```python
@mlc.Func.register("mlc.Opaque.default.serialize")
def _default_serialize(opaques: list[Any]) -> str:
    return jsonpickle.dumps(list(opaques))

@mlc.Func.register("mlc.Opaque.default.deserialize")
def _default_deserialize(json_str: str) -> list[Any]:
    return jsonpickle.loads(json_str)
```

`jsonpickle` is not a perfect library - usually `pickle` or `cloudpickle` could be substantially better in terms of feature completeness, but it actually gives a balance between serializability and readability.